### PR TITLE
Update deploment repository and add support for ED25519 keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       execjs (~> 2)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    bcrypt_pbkdf (1.1.1)
     better_html (2.1.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -196,6 +197,7 @@ GEM
       devise (>= 4.3.0)
     diff-lcs (1.6.0)
     docile (1.4.0)
+    ed25519 (1.4.0)
     email_spec (2.3.0)
       htmlentities (~> 4.3.3)
       launchy (>= 2.1, < 4.0)
@@ -723,6 +725,7 @@ DEPENDENCIES
   ancestry (~> 4.3.3)
   audited (~> 5.7.0)
   autoprefixer-rails (~> 10.4.19)
+  bcrypt_pbkdf
   bing_translator (~> 6.2.0)
   cancancan (~> 3.6.1)
   capistrano (~> 3.19.2)
@@ -743,6 +746,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1.10)
   devise (~> 4.9.4)
   devise-security (~> 0.18.0)
+  ed25519
   email_spec (~> 2.3.0)
   erb_lint (~> 0.9.0)
   exiftool_vendored (~> 12.97.0)

--- a/Gemfile_custom
+++ b/Gemfile_custom
@@ -24,3 +24,6 @@
 ###### Other gems ######
 #
 # Add your custom gem dependencies here
+
+gem "ed25519"
+gem "bcrypt_pbkdf"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,7 +22,7 @@ set :application, deploysecret(:app_name, default: "consul")
 set :deploy_to, deploysecret(:deploy_to)
 set :ssh_options, port: deploysecret(:ssh_port)
 
-set :repo_url, "https://github.com/consuldemocracy/consuldemocracy.git"
+set :repo_url, "https://github.com/osoigo/consuldemocracy.git"
 
 set :revision, `git rev-parse --short #{fetch(:branch)}`.strip
 


### PR DESCRIPTION
## Objectives

1. Configure this fork so it deploys this fork.
2. Add support for ED25519 keys

Capistrano needs the ssh-kit gem, which needs the net-ssh keys for doing deployments over SSH. The current version of the net-ssh gem does not support ED25519. 

Probably at some point Capistrano dependencies will include the `bcrypt_pbkdf` and `ed22519` gems.  At that point we can safely remove the commit: 7252649

## Visual Changes
None
