### PR TITLE
Configure Pronto to run in this fork

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Fetch base branch
         run: git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
       - name: Run pronto
-        run: bundle exec pronto run -f text -c ${{ github.event.pull_request.base.ref }}
+        run: bundle exec pronto run -f text --exit-code -c ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Fetch base branch
         run: git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
       - name: Run pronto
-        run: PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")" PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" bundle exec pronto run -f github_status github_pr -c origin/${{ github.base_ref }}
+        run: bundle exec pronto run -f text -c ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -21,5 +21,7 @@ jobs:
           node-version-file: ".node-version"
       - name: Install node packages
         run: npm clean-install
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
       - name: Run pronto
         run: PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")" PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" bundle exec pronto run -f github_status github_pr -c origin/${{ github.base_ref }}


### PR DESCRIPTION
## Objectives

Configure pronto to run in this fork.

Initially we tried to make it work as the original repository (consuldemocracy/consuldemocracy) but we were not able to do it because Github permissions errors. In the original repository when pronto detects an error it writes comments in the PR helping the developers to find the errors they introduced.

In this version, instead of having commits in the PR we will have a failing workflow and the errors detected logged in the Github Actions pronto workflow logs.

Thanks to this PR we can forget running pronto locally as we will be notified by the Pronto workflow.
