### PR TITLE
feat: allow customizing controller concerns

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -140,6 +140,7 @@ module Consul
     [
       "app/components/custom",
       "app/controllers/custom",
+      "app/controllers/custom/concerns",
       "app/form_builders/custom",
       "app/graphql/custom",
       "app/lib/custom",


### PR DESCRIPTION
## Objectives

In our particular case we had to override the form of bucket headings to add a new parameter. The current implementation uses the `Admin::BudgetHeadingsActions` concern for nearly all the controller logic, so we had to customize that to modify the `allowed_params` method.

This simple change allows customizing controller concerns.