### PR TITLE
Update deployments default branch

### DIFF
--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -1,3 +1,3 @@
-set :branch, ENV["branch"] || :master
+set :branch, ENV["branch"] || :stable
 
 server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,4 @@
-set :branch, ENV["branch"] || :master
+set :branch, ENV["branch"] || :stable
 
 server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]
 #server deploysecret(:server2), user: deploysecret(:user), roles: %w(web app db importer cron background)

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,3 +1,3 @@
-set :branch, ENV["branch"] || :master
+set :branch, ENV["branch"] || :stable
 
 server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]


### PR DESCRIPTION
## References

* #2 

## Objectives

As we changed the default branch from `master` to `stable` in this repository it has sense to set the default deployment branch to the same branch.