### PR TITLE
Customize account verification steps

### DIFF
--- a/app/components/custom/account/permissions_list_component.rb
+++ b/app/components/custom/account/permissions_list_component.rb
@@ -1,0 +1,4 @@
+load Rails.root.join("app", "components", "account", "permissions_list_component.rb")
+
+class Account::PermissionsListComponent
+end

--- a/app/components/custom/account/permissions_list_component.rb
+++ b/app/components/custom/account/permissions_list_component.rb
@@ -1,4 +1,19 @@
 load Rails.root.join("app", "components", "account", "permissions_list_component.rb")
 
 class Account::PermissionsListComponent
+  private
+
+    def permissions
+      perms = {}
+      perms[t("verification.user_permission_debates")] = true if Setting["process.debates"].present?
+      if Setting["process.proposals"].present?
+        perms[t("verification.user_permission_proposal")] = true
+      end
+      if Setting["process.budgets"].present?
+        perms[t("verification.user_permission_budget_investment")] = user.level_two_or_three_verified?
+      end
+      perms[t("verification.user_permission_support_proposal")] = user.level_two_or_three_verified?
+      perms[t("verification.user_permission_votes")] = user.level_three_verified?
+      perms
+    end
 end

--- a/app/controllers/custom/verification/residence_controller.rb
+++ b/app/controllers/custom/verification/residence_controller.rb
@@ -1,0 +1,12 @@
+load Rails.root.join("app", "controllers", "verification", "residence_controller.rb")
+
+class Verification::ResidenceController
+  def create
+    @residence = Verification::Residence.new(residence_params.merge(user: current_user))
+    if @residence.save
+      redirect_to account_path, notice: t("verification.residence.create.flash.success")
+    else
+      render :new
+    end
+  end
+end

--- a/app/models/custom/verification/residence.rb
+++ b/app/models/custom/verification/residence.rb
@@ -33,12 +33,14 @@ class Verification::Residence
       habitante = census_data.datos_habitante
       vivienda = census_data.datos_vivienda
 
+      timestamp = Time.current
       user.update(document_number: document_number, # rubocop:disable Rails/SaveBang
                   document_type: document_type,
                   geozone: geozone,
                   date_of_birth: date_of_birth.in_time_zone.to_datetime,
                   gender: gender,
-                  residence_verified_at: Time.current,
+                  residence_verified_at: timestamp,
+                  verified_at: timestamp,
                   nIA: habitante[:nia],
                   name: habitante[:nombre],
                   first_name: habitante[:primer_apellido],

--- a/app/views/custom/verification/residence/new.html.erb
+++ b/app/views/custom/verification/residence/new.html.erb
@@ -1,0 +1,82 @@
+<div class="verification account row">
+  <div class="small-12 column">
+
+    <div class="text-center">
+      <div class="small-4 column verification-step is-active">
+        <span class="number">1</span> <%= t("verification.step_1") %>
+      </div>
+      <div class="small-4 column verification-step">
+        <span class="number">2</span> <%= t("verification.step_2") %>
+      </div>
+      <div class="small-4 column verification-step">
+        <span class="number">3</span> <%= t("verification.step_3") %>
+      </div>
+    </div>
+
+    <div class="progress small-12 success">
+      <span class="meter" style="width: 33%"></span>
+    </div>
+
+    <%= back_link_to account_path, t("verification.back") %>
+
+    <h1><%= t("verification.residence.new.title") %></h1>
+
+    <div class="user-permissions small-12">
+      <p><%= t("verification.user_permission_info") %></p>
+
+      <%= render Account::PermissionsListComponent.new(User.new(level_two_verified_at: Time.current)) %>
+    </div>
+
+    <%= form_for @residence, as: "residence", url: residence_path do |f| %>
+      <%= render "errors" %>
+
+      <div class="row">
+        <div class="small-12 medium-8">
+          <div class="small-12 medium-3 column">
+            <%= f.select :document_type, document_types, prompt: "" %>
+          </div>
+          <div class="small-12 medium-5 column end">
+
+            <div class="inline-block">
+              <%= f.label :document_number, t("verification.residence.new.document_number") %>
+            </div>
+
+            <button type="button" class="inline-block" data-toggle="info-document-number">
+              <span class="icon-help"></span>
+              <span class="show-for-sr"><%= t("verification.residence.new.document_number_help_title") %></span>
+            </button>
+
+            <div class="dropdown-pane" id="info-document-number" data-dropdown
+                 data-hover="true" data-hover-pane="true">
+              <%= sanitize(t("verification.residence.new.document_number_help_text")) %>
+            </div>
+
+            <%= f.text_field :document_number, label: false %>
+          </div>
+        </div>
+      </div>
+
+      <div class="date-of-birth small-12 medium-6 clear">
+        <%= render Shared::DateOfBirthFieldComponent.new(f) %>
+      </div>
+
+      <div class="small-12 medium-5 clear">
+        <%= f.text_field :postal_code,
+                         hint: t("verification.residence.new.postal_code_note") %>
+      </div>
+
+      <div class="small-12">
+        <%= f.check_box :terms_of_service,
+                        label: t("verification.residence.new.accept_terms_text",
+                                 terms_url: new_window_link_to(t("verification.residence.new.terms"),
+                                                               page_path("census_terms"))) %>
+      </div>
+
+      <div class="small-12 medium-3 clear">
+        <%= f.submit t("verification.residence.new.verify_residence"),
+                     id: "new_residence_submit",
+                     class: "button success expanded" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/custom/verification/residence/new.html.erb
+++ b/app/views/custom/verification/residence/new.html.erb
@@ -7,7 +7,7 @@
     <div class="user-permissions small-12">
       <p><%= t("verification.user_permission_info") %></p>
 
-      <%= render Account::PermissionsListComponent.new(User.new(level_two_verified_at: Time.current)) %>
+      <%= render Account::PermissionsListComponent.new(User.new(level_two_verified_at: Time.current, verified_at: Time.current)) %>
     </div>
 
     <%= form_for @residence, as: "residence", url: residence_path do |f| %>

--- a/app/views/custom/verification/residence/new.html.erb
+++ b/app/views/custom/verification/residence/new.html.erb
@@ -1,22 +1,5 @@
 <div class="verification account row">
   <div class="small-12 column">
-
-    <div class="text-center">
-      <div class="small-4 column verification-step is-active">
-        <span class="number">1</span> <%= t("verification.step_1") %>
-      </div>
-      <div class="small-4 column verification-step">
-        <span class="number">2</span> <%= t("verification.step_2") %>
-      </div>
-      <div class="small-4 column verification-step">
-        <span class="number">3</span> <%= t("verification.step_3") %>
-      </div>
-    </div>
-
-    <div class="progress small-12 success">
-      <span class="meter" style="width: 33%"></span>
-    </div>
-
     <%= back_link_to account_path, t("verification.back") %>
 
     <h1><%= t("verification.residence.new.title") %></h1>

--- a/app/views/custom/verification/verified_user/show.html.erb
+++ b/app/views/custom/verification/verified_user/show.html.erb
@@ -1,0 +1,43 @@
+<div class="verification account row">
+  <div class="small-12 column">
+
+    <%= back_link_to account_path, t("verification.back") %>
+
+    <h1><%= t("verification.verified_user.show.title") %></h1>
+
+    <p><%= t("verification.verified_user.show.explanation") %></p>
+
+    <% if @verified_users.map(&:email).any? %>
+      <h2><%= t("verification.verified_user.show.email_title") %></h2>
+      <ul class="verification-list">
+        <% @verified_users.each do |verified_user| %>
+          <% if verified_user.email.present? %>
+            <li id="<%= dom_id(verified_user) %>_email">
+              <span><%= mask_email(verified_user.email) %></span>
+              <span><%= render "form", url: email_path, verified_user: verified_user %></span>
+            </li>
+          <% end %>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <% if @verified_users.map(&:phone).any? %>
+      <h2><%= t("verification.verified_user.show.phone_title") %></h2>
+      <ul class="verification-list">
+        <% @verified_users.each do |verified_user| %>
+          <% if verified_user.phone.present? %>
+            <li id="<%= dom_id(verified_user) %>_phone" class="float-left">
+              <span><%= mask_phone(verified_user.phone) %></span>
+              <span><%= render "form", url: sms_path, verified_user: verified_user %></span>
+            </li>
+          <% end %>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <div class="margin clear">
+      <%= link_to t("verification.verified_user.show.use_another_phone"), new_sms_path %>
+    </div>
+
+  </div>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -125,6 +125,7 @@ ignore_missing:
   - "devise.failure.invalid"
   - "devise.registrations.destroyed"
   - "devise.password_expired.*"
+  - "verification.user_permission_budget_investment"
 
 ## Consider these keys used:
 ignore_unused:

--- a/config/locales/custom/es/verification.yml
+++ b/config/locales/custom/es/verification.yml
@@ -1,0 +1,3 @@
+es:
+  verification:
+    user_permission_budget_investment: Crear nuevas propuestas de inversión

--- a/config/locales/custom/val/verification.yml
+++ b/config/locales/custom/val/verification.yml
@@ -1,0 +1,3 @@
+val:
+  verification:
+    user_permission_budget_investment: Crear noves propostes d'inversió

--- a/spec/system/custom/polls/voter_spec.rb
+++ b/spec/system/custom/polls/voter_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+describe "Voter" do
+  context "Origin", :with_frozen_time do
+    let(:poll) { create(:poll) }
+    let!(:question) { create(:poll_question, :yes_no, poll: poll) }
+    let(:booth) { create(:poll_booth) }
+    let(:officer) { create(:poll_officer) }
+    let(:admin) { create(:administrator) }
+
+    before do
+      create(:geozone, :in_census)
+      create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
+      create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth)
+    end
+
+    scenario "Voting in poll and then verifiying account" do
+      allow_any_instance_of(Verification::Sms).to receive(:generate_confirmation_code).and_return("1357")
+      user = create(:user)
+      admin_user = admin.user
+
+      login_through_form_as_officer(officer)
+      vote_for_poll_via_booth
+
+      logout
+      login_as user
+      visit account_path
+      click_link "Verify my account"
+
+      verify_residence
+      confirm_phone(code: "1357")
+
+      visit poll_path(poll)
+
+      within("#poll_question_#{question.id}_options") do
+        expect(page).not_to have_button("Yes")
+      end
+
+      expect(page).to have_content "You have already participated in a physical booth. " \
+                                   "You can not participate again."
+
+      logout
+      login_as(admin_user)
+      visit admin_poll_recounts_path(poll)
+
+      within("#total_system") do
+        expect(page).to have_content "1"
+      end
+
+      within "tr", text: booth.name do
+        expect(page).to have_content "1"
+      end
+    end
+  end
+end

--- a/spec/system/custom/polls/voter_spec.rb
+++ b/spec/system/custom/polls/voter_spec.rb
@@ -28,7 +28,6 @@ describe "Voter" do
       click_link "Verify my account"
 
       verify_residence
-      confirm_phone(code: "1357")
 
       visit poll_path(poll)
 

--- a/spec/system/polls/voter_spec.rb
+++ b/spec/system/polls/voter_spec.rb
@@ -185,7 +185,7 @@ describe "Voter" do
       end
     end
 
-    scenario "Voting in poll and then verifiying account" do
+    scenario "Voting in poll and then verifiying account", :consul do
       allow_any_instance_of(Verification::Sms).to receive(:generate_confirmation_code).and_return("1357")
       user = create(:user)
       admin_user = admin.user

--- a/spec/system/verification/level_three_verification_spec.rb
+++ b/spec/system/verification/level_three_verification_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Level three verification" do
+describe "Level three verification", :consul do
   scenario "Verification with residency and verified sms" do
     allow_any_instance_of(Verification::Sms).to receive(:generate_confirmation_code).and_return("2015")
     create(:geozone)


### PR DESCRIPTION
## References

This PR depends on:
* #6 

## Objetivos
Ocultar las partes innecesarias del proceso de verificación de cuenta.

Consul Democracy tiene 3 pasos de verificación por defecto:
1. Verificación de residencia
2. Verificación de número de teléfono móvil
3. Verificación por carta

Solo necesitamos el paso de verificación de residencia.

## Visual Changes
1. Eliminar el indicador de pasos de la nueva vista de verificación de residencia.
2. Actualizar la lista de permisos de la cuenta para que muestre los permisos correctamente.

## Screenshots

### Before
Las capturas de pantalla que aparecen a continuación son de la implementación original de Consul Democracy.

**Pantalla que ve el usuario después de iniciar sesión por primera vez.** 
Se puede editar en el panel de administración
<img width="1888" height="1380" alt="Screen Shot 2025-07-22 at 16 23 53-fullpage" src="https://github.com/user-attachments/assets/0f046adb-a6a6-4970-803c-a9c7c2b02400" />

**Pantalla con la cuenta de un usuario no verificado**
<img width="1888" height="1822" alt="Screen Shot 2025-07-22 at 16 24 05-fullpage" src="https://github.com/user-attachments/assets/18f2d7fb-f6aa-45b6-9522-42c26e89ac12" />

**Pantalla de verificación de residencia original**
<img width="1888" height="1807" alt="Screen Shot 2025-07-22 at 16 24 20-fullpage" src="https://github.com/user-attachments/assets/378b0a88-8347-47d5-be36-3dd25aa23d1c" />

### After
Las capturas de pantalla a continuación pertenecen a los cambios de esta PR.


**Pantalla que ve el usuario después de iniciar sesión por primera vez.** 
Se puede editar en el panel de administración y adaptar a nuestra configuración de verificación.
<img width="1888" height="1380" alt="Screen Shot 2025-07-22 at 16 23 53-fullpage" src="https://github.com/user-attachments/assets/0f046adb-a6a6-4970-803c-a9c7c2b02400" />

**Pantalla con la cuenta de un usuario no verificado**
Se han cambiado ligeramente los mensajes de la versión original para que se parezca a lo que teníamos en el portal anterior.
<img width="1888" height="1822" alt="Screen Shot 2025-07-22 at 17 04 36-fullpage" src="https://github.com/user-attachments/assets/fb8e59d9-ce45-460f-b6e8-d61b7d4d58c1" />

**Pantalla de verificación de residencia sin el indicador de pasos actual**
<img width="1888" height="1660" alt="Screen Shot 2025-07-22 at 17 04 42-fullpage" src="https://github.com/user-attachments/assets/c0ef42df-37e6-443a-914e-e1bafdd1716b" />

**Pantalla que ve el usuario después de haber verificado la residencia.**
Se han adaptado los mensajes ligeramente, 
<img width="1888" height="1822" alt="Screen Shot 2025-07-22 at 17 05 05-fullpage" src="https://github.com/user-attachments/assets/4eabb443-c0f0-40ed-aada-087cf2318e56" />



