### PR TITLE
Fix deployment node prefix when using multiple servers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -121,9 +121,10 @@ task :map_node_bins do
   on roles(:app) do
     within release_path do
       with rails_env: fetch(:rails_env) do
-        prefix = -> { "EXECJS_RUNTIME='' #{fetch(:fnm_path)}/fnm exec" }
+        prefix = "EXECJS_RUNTIME='' #{fetch(:fnm_path)}/fnm exec"
 
         fetch(:fnm_map_bins).each do |command|
+          SSHKit.config.command_map.prefix[command.to_sym].delete(prefix)
           SSHKit.config.command_map.prefix[command.to_sym].unshift(prefix)
         end
       end


### PR DESCRIPTION
## Objectives
Fix Capistrano deployments when using multiple app servers.

## Description
When Capistrano runs on multiple hosts, it prepends this prefix for every host, so you end up with:

```
EXECJS_RUNTIME='' $HOME/.fnm/fnm exec EXECJS_RUNTIME='' $HOME/.fnm/fnm exec npm install ...
```

This is not a valid command, and SSHKit tries to execute `EXECJS_RUNTIME=`, which fails.

By using a string, not a lambda, for the prefix, and ensuring it is not prepended multiple times.

## Error
```
(See full trace by running task with --trace)
 bundle exec cap preproduction npm:install
00:00 rvm1:hook
      01 mkdir -p /var/consul/rvm1scripts/
    ✔ 01 deploy@server-app2 1.118s
      Uploading /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/rvm1-capistrano3-1.4.0/script/rvm-auto.sh 100.0%
      02 chmod +x /var/consul/rvm1scripts/rvm-auto.sh
    ✔ 02 deploy@server-app2 0.099s
00:01 npm:install
      01 EXECJS_RUNTIME='' $HOME/.fnm/fnm exec npm install --production --silent --no-progress
    ✔ 01 deploy@server-app2 1.174s
 bundle exec cap preproduction npm:install
00:00 rvm1:hook
      01 mkdir -p /var/consul/rvm1scripts/
    ✔ 01 deploy@server-app1 1.058s
      Uploading /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/rvm1-capistrano3-1.4.0/script/rvm-auto.sh 100.0%
      02 chmod +x /var/consul/rvm1scripts/rvm-auto.sh
    ✔ 02 deploy@server-app1 0.107s
00:01 npm:install
      01 EXECJS_RUNTIME='' $HOME/.fnm/fnm exec npm install --production --silent --no-progress
    ✔ 01 deploy@server-app1 1.340s
 bundle exec cap preproduction npm:install
00:00 rvm1:hook
      01 mkdir -p /var/consul/rvm1scripts/
    ✔ 01 deploy@server-app2 0.876s
    ✔ 01 deploy@server-app1 0.884s
      Uploading /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/rvm1-capistrano3-1.4.0/script/rvm-auto.sh 100.0%
      Uploading /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/rvm1-capistrano3-1.4.0/script/rvm-auto.sh 100.0%
      02 chmod +x /var/consul/rvm1scripts/rvm-auto.sh
    ✔ 02 deploy@server-app2 0.102s
    ✔ 02 deploy@server-app1 0.111s
00:01 npm:install
      01 EXECJS_RUNTIME='' $HOME/.fnm/fnm exec EXECJS_RUNTIME='' $HOME/.fnm/fnm exec npm install --production --silent --no-progress
      01 error: Can't spawn program: No such file or directory (os error 2)
      01 Maybe the program EXECJS_RUNTIME= does not exist on not available in PATH?
#<Thread:0x0000736117deafa8 /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/runners/parallel.rb:8 run> terminated with exception (report_on_exception is true):
/home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/runners/parallel.rb:13:in `rescue in block (2 levels) in execute': Exception while executing as deploy@ivlcparticipa-app2: npm
npm stdout: error: Can't spawn program: No such file or directory (os error 2)
Maybe the program EXECJS_RUNTIME= does not exist on not available in PATH?
npm stderr: Nothing written

        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/runners/parallel.rb:9:in `block (2 levels) in execute'
/home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/command.rb:97:in `exit_status=': npm exit status: 1 (SSHKit::Command::Failed)
npm stdout: error: Can't spawn program: No such file or directory (os error 2)
Maybe the program EXECJS_RUNTIME= does not exist on not available in PATH?
npm stderr: Nothing written

        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/netssh.rb:185:in `execute_command'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:147:in `block in create_command_and_execute'
        from <internal:kernel>:90:in `tap'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:147:in `create_command_and_execute'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:80:in `execute'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/capistrano-npm-1.0.3/lib/capistrano/tasks/npm.rake:19:in `block (5 levels) in <top (required)>'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:100:in `with'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/capistrano-npm-1.0.3/lib/capistrano/tasks/npm.rake:18:in `block (4 levels) in <top (required)>'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:92:in `within'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/capistrano-npm-1.0.3/lib/capistrano/tasks/npm.rake:17:in `block (3 levels) in <top (required)>'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:31:in `instance_exec'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:31:in `run'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/runners/parallel.rb:10:in `block (2 levels) in execute'
      01 error: Can't spawn program: No such file or directory (os error 2)
      01 Maybe the program EXECJS_RUNTIME= does not exist on not available in PATH?
#<Thread:0x0000736117deb1d8 /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/runners/parallel.rb:8 run> terminated with exception (report_on_exception is true):
/home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/runners/parallel.rb:13:in `rescue in block (2 levels) in execute': Exception while executing as deploy@ivlcparticipa-app1: npm exit status: 1 (SSHKit::Runner::ExecuteError)
npm stdout: error: Can't spawn program: No such file or directory (os error 2)
Maybe the program EXECJS_RUNTIME= does not exist on not available in PATH?
npm stderr: Nothing written

        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/runners/parallel.rb:9:in `block (2 levels) in execute'
/home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/command.rb:97:in `exit_status=': npm exit status: 1 (SSHKit::Command::Failed)
npm stdout: error: Can't spawn program: No such file or directory (os error 2)
Maybe the program EXECJS_RUNTIME= does not exist on not available in PATH?
npm stderr: Nothing written

        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/netssh.rb:185:in `execute_command'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:147:in `block in create_command_and_execute'
        from <internal:kernel>:90:in `tap'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:147:in `create_command_and_execute'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:80:in `execute'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/capistrano-npm-1.0.3/lib/capistrano/tasks/npm.rake:19:in `block (5 levels) in <top (required)>'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:100:in `with'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/capistrano-npm-1.0.3/lib/capistrano/tasks/npm.rake:18:in `block (4 levels) in <top (required)>'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:92:in `within'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/capistrano-npm-1.0.3/lib/capistrano/tasks/npm.rake:17:in `block (3 levels) in <top (required)>'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:31:in `instance_exec'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:31:in `run'
        from /home/sendero/.local/share/mise/installs/ruby/3.2.8/lib/ruby/gems/3.2.0/gems/sshkit-1.24.0/lib/sshkit/runners/parallel.rb:10:in `block (2 levels) in execute'
(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as deploy@ivlcparticipa-app1: npm exit status: 1 (SSHKit::Runner::ExecuteError)
npm stdout: error: Can't spawn program: No such file or directory (os error 2)
Maybe the program EXECJS_RUNTIME= does not exist on not available in PATH?
npm stderr: Nothing written


Caused by:
SSHKit::Command::Failed: npm exit status: 1 (SSHKit::Command::Failed)
npm stdout: error: Can't spawn program: No such file or directory (os error 2)
Maybe the program EXECJS_RUNTIME= does not exist on not available in PATH?
npm stderr: Nothing written

Tasks: TOP => npm:install
(See full trace by running task with --trace)
```