### PR TITLE
Budget heading required support

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Fetch base branch
         run: git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
       - name: Run pronto
-        run: bundle exec pronto run -f text -c ${{ github.event.pull_request.base.ref }}
+        run: bundle exec pronto run -f text --exit-code -c ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Fetch base branch
         run: git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
       - name: Run pronto
-        run: PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")" PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" bundle exec pronto run -f github_status github_pr -c origin/${{ github.base_ref }}
+        run: bundle exec pronto run -f text -c ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -21,5 +21,7 @@ jobs:
           node-version-file: ".node-version"
       - name: Install node packages
         run: npm clean-install
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
       - name: Run pronto
         run: PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")" PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" bundle exec pronto run -f github_status github_pr -c origin/${{ github.base_ref }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       execjs (~> 2)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    bcrypt_pbkdf (1.1.1)
     better_html (2.1.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -196,6 +197,7 @@ GEM
       devise (>= 4.3.0)
     diff-lcs (1.6.0)
     docile (1.4.0)
+    ed25519 (1.4.0)
     email_spec (2.3.0)
       htmlentities (~> 4.3.3)
       launchy (>= 2.1, < 4.0)
@@ -723,6 +725,7 @@ DEPENDENCIES
   ancestry (~> 4.3.3)
   audited (~> 5.7.0)
   autoprefixer-rails (~> 10.4.19)
+  bcrypt_pbkdf
   bing_translator (~> 6.2.0)
   cancancan (~> 3.6.1)
   capistrano (~> 3.19.2)
@@ -743,6 +746,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1.10)
   devise (~> 4.9.4)
   devise-security (~> 0.18.0)
+  ed25519
   email_spec (~> 2.3.0)
   erb_lint (~> 0.9.0)
   exiftool_vendored (~> 12.97.0)

--- a/Gemfile_custom
+++ b/Gemfile_custom
@@ -24,3 +24,6 @@
 ###### Other gems ######
 #
 # Add your custom gem dependencies here
+
+gem "ed25519"
+gem "bcrypt_pbkdf"

--- a/app/components/custom/admin/budget_headings/form_component.html.erb
+++ b/app/components/custom/admin/budget_headings/form_component.html.erb
@@ -1,0 +1,62 @@
+<%= translatable_form_for heading, url: path, html: { class: "budget-headings-form" } do |f| %>
+  <%= render "shared/globalize_locales", resource: heading %>
+
+  <%= render "shared/errors", resource: heading %>
+
+  <%= render Admin::BudgetsWizard::ModeFieldComponent.new %>
+
+  <%= f.translatable_fields do |translations_form| %>
+    <div class="small-12 medium-6 column end">
+      <%= translations_form.text_field :name, maxlength: 50 %>
+    </div>
+  <% end %>
+
+  <div class="small-12 medium-6">
+    <% if budget.show_money? %>
+      <%= f.text_field :price, maxlength: 8 %>
+    <% else %>
+      <%= f.hidden_field :price, value: 0 %>
+    <% end %>
+
+    <%= f.text_field :required_support,
+                      maxlength: 8,
+                      hint: t("admin.budget_headings.form.required_support_info") %>
+
+    <% if feature?(:map) %>
+      <%= f.select :geozone_id,
+                   geozone_options,
+                   include_blank: t("geozones.none"),
+                   hint: t("admin.budget_headings.form.geozone_info") %>
+    <% end %>
+
+    <% if heading.budget.approval_voting? %>
+      <%= f.number_field :max_ballot_lines,
+                         hint: t("admin.budget_headings.form.max_ballot_lines_info") %>
+    <% end %>
+
+    <%= f.text_field :population,
+                     maxlength: 8,
+                     data: { toggle_focus: "population-info" },
+                     hint: t("admin.budget_headings.form.population_info") %>
+
+    <%= f.text_field :latitude, maxlength: 22 %>
+    <%= f.text_field :longitude, maxlength: 22 %>
+    <p class="help-text" id="budgets-coordinates-help-text">
+      <%= t("admin.budget_headings.form.coordinates_info") %>
+    </p>
+
+    <%= f.check_box :allow_custom_content %>
+    <p class="help-text" id="budgets-content-blocks-help-text">
+      <%= t("admin.budget_headings.form.content_blocks_info") %>
+    </p>
+  </div>
+
+  <div class="clear">
+    <% if single_heading? %>
+      <%= f.submit t("admin.budgets_wizard.headings.continue"), class: "button success" %>
+    <% else %>
+      <%= f.submit t("admin.budget_headings.form.#{action}"), class: "button hollow" %>
+    <% end %>
+  </div>
+<% end %>
+

--- a/app/components/custom/admin/budget_headings/form_component.rb
+++ b/app/components/custom/admin/budget_headings/form_component.rb
@@ -1,0 +1,6 @@
+class Admin::BudgetHeadings::FormComponent < ApplicationComponent; end
+
+load Rails.root.join("app", "components", "admin", "budget_headings", "form_component.rb")
+
+class Admin::BudgetHeadings::FormComponent
+end

--- a/app/components/custom/budgets/investments/votes_component.html.erb
+++ b/app/components/custom/budgets/investments/votes_component.html.erb
@@ -1,0 +1,51 @@
+<div class="supports">
+
+  <span class="total-supports <%= "no-button" unless voting_allowed? || user_voted_for? %>">
+    <%= t("budgets.investments.investment.supports", count: investment.total_votes) %>
+  </span>
+
+  <div class="in-favor">
+    <% if investment.should_show_votes? %>
+      <% if user_voted_for? %>
+        <div class="supported">
+          <div class="callout success">
+            <%= t("budgets.investments.votes.already_supported") %>
+          </div>
+          <% if feature?(:remove_investments_supports) %>
+            <%= button_to t("budgets.investments.votes.remove_support"),
+                          remove_support_path,
+                          class: "button button-remove-support expanded",
+                          method: "delete",
+                          remote: true,
+                          "aria-label": remove_support_aria_label %>
+          <% end %>
+        </div>
+      <% else %>
+        <% if investment.has_required_support? %>
+          <div class="has-required-supports"><%= t("budgets.investments.votes.has_required_support") %></div>
+        <% else %>
+          <%= button_to t("budgets.investments.votes.support"), support_path,
+                        class: "button button-support expanded",
+                        title: t("budgets.investments.investment.support_title"),
+                        method: "post",
+                        remote: !display_support_alert?,
+                        data: ({ confirm: confirm_vote_message } if display_support_alert?),
+                        "aria-label": support_aria_label %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%= render Shared::ParticipationNotAllowedComponent.new(investment, cannot_vote_text: cannot_vote_text) %>
+
+  <% if user_voted_for? && setting["twitter_handle"] %>
+    <div class="share-supported">
+      <%= render "shared/social_share",
+                 title: investment.title,
+                 image_url: image_absolute_url(investment.image, :thumb),
+                 url: budget_investment_url(investment.budget, investment),
+                 description: investment.title,
+                 mobile: investment.title %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/custom/budgets/investments/votes_component.rb
+++ b/app/components/custom/budgets/investments/votes_component.rb
@@ -1,0 +1,6 @@
+class Budgets::Investments::VotesComponent < ApplicationComponent; end
+
+load Rails.root.join("app", "components", "budgets", "investments", "votes_component.rb")
+
+class Budgets::Investments::VotesComponent
+end

--- a/app/controllers/custom/concerns/admin/budget_headings_actions.rb
+++ b/app/controllers/custom/concerns/admin/budget_headings_actions.rb
@@ -1,0 +1,11 @@
+require_dependency Rails.root.join('app', 'controllers',  'concerns', 'admin', 'budget_headings_actions').to_s
+
+module Admin::BudgetHeadingsActions
+  private
+
+    alias_method :consul_allowed_params, :allowed_params
+
+    def allowed_params
+      consul_allowed_params + [:required_support]
+    end
+end

--- a/app/models/custom/budget/investment.rb
+++ b/app/models/custom/budget/investment.rb
@@ -1,0 +1,17 @@
+require_dependency Rails.root.join('app', 'models', 'budget', 'investment').to_s
+
+class Budget
+  class Investment
+    scope :enough_support, -> {
+      joins(:heading).where("budget_investments.cached_votes_up + budget_investments.physical_votes >= budget_headings.required_support")
+    }
+
+    def has_required_support?
+      if heading.required_support.present?
+        return heading.required_support <= total_votes
+      end
+      return false
+    end
+  end
+end
+

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,7 +22,7 @@ set :application, deploysecret(:app_name, default: "consul")
 set :deploy_to, deploysecret(:deploy_to)
 set :ssh_options, port: deploysecret(:ssh_port)
 
-set :repo_url, "https://github.com/consuldemocracy/consuldemocracy.git"
+set :repo_url, "https://github.com/osoigo/consuldemocracy.git"
 
 set :revision, `git rev-parse --short #{fetch(:branch)}`.strip
 

--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -1,3 +1,3 @@
-set :branch, ENV["branch"] || :master
+set :branch, ENV["branch"] || :stable
 
 server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,4 @@
-set :branch, ENV["branch"] || :master
+set :branch, ENV["branch"] || :stable
 
 server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]
 #server deploysecret(:server2), user: deploysecret(:user), roles: %w(web app db importer cron background)

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,3 +1,3 @@
-set :branch, ENV["branch"] || :master
+set :branch, ENV["branch"] || :stable
 
 server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -1,0 +1,5 @@
+es:
+  activerecord:
+    attributes:
+      budget/heading:
+        required_support: "Apoyos necesarios"

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -1,0 +1,5 @@
+es:
+  admin:
+    budget_headings:
+      form:
+        required_support_info: "Si la propuesta obtiene este número de apoyos se avisará a los usuarios que ya no necesita más para poder pasar a la siguiente fase."

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -1,0 +1,5 @@
+es:
+  budgets:
+    investments:
+      votes:
+        has_required_support: "Esta propuesta pasa a la siguiente fase"

--- a/config/locales/custom/val/budgets.yml
+++ b/config/locales/custom/val/budgets.yml
@@ -1,0 +1,5 @@
+es:
+  budgets:
+    investments:
+      votes:
+        has_required_support: "Esta proposta passa a la següent fase"

--- a/db/migrate/20250623081603_add_required_support_to_budget_heading.rb
+++ b/db/migrate/20250623081603_add_required_support_to_budget_heading.rb
@@ -1,0 +1,5 @@
+class AddRequiredSupportToBudgetHeading < ActiveRecord::Migration[7.0]
+  def change
+    add_column :budget_headings, :required_support, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_13_014205) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_23_081603) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -235,6 +235,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_13_014205) do
     t.integer "max_ballot_lines", default: 1
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.integer "required_support"
     t.index ["geozone_id"], name: "index_budget_headings_on_geozone_id"
     t.index ["group_id"], name: "index_budget_headings_on_group_id"
   end

--- a/spec/components/custom/budgets/investments/votes_component_spec.rb
+++ b/spec/components/custom/budgets/investments/votes_component_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe Budgets::Investments::VotesComponent do
+  describe "vote link" do
+    context "when investment shows votes" do
+      let(:heading) { create(:budget_heading ) }
+      let(:investment) { create(:budget_investment, heading: heading) }
+      let(:component) { Budgets::Investments::VotesComponent.new(investment) }
+
+      before { allow(investment).to receive(:should_show_votes?).and_return(true) }
+
+      it "hides button when enough support reached" do
+        sign_in(create(:user))
+
+        render_inline component
+        expect(page).to have_button
+
+        heading.required_support = 1
+        render_inline component
+        expect(page).to have_button
+
+        investment.vote_by(voter: create(:user), vote: "yes")
+        render_inline component
+        expect(page).not_to have_button
+      end
+    end
+  end
+end
+

--- a/spec/models/custom/budget/investment_spec.rb
+++ b/spec/models/custom/budget/investment_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Budget::Investment do
+  it "says if enough support is reached when the heading has enough_support set" do
+    budget = create(:budget, :selecting)
+    heading = create(:budget_heading, budget: budget)
+    investment = create(:budget_investment, budget: budget)
+
+    expect(investment.has_required_support?).to be false
+    investment.heading.required_support = 1
+    expect(investment.has_required_support?).to be false
+    investment.register_selection(create(:user, :level_two))
+    expect(investment.has_required_support?).to be true
+    investment.heading.required_support = 2
+    expect(investment.has_required_support?).to be false
+  end
+end


### PR DESCRIPTION
## Objectives

Permitir establecer los apoyos necesarios que necesitan las propuestas de gasto de una partida para que sean aceptadas.

## Visual Changes

Cuando una propuesta tiene apoyos suficientes deja de mostrar el botón para apoyar.

El formulario de partidas presupuestarias tiene un nuevo campo para indicar el apoyo necesario.