### PR TITLE
Filtros de propuestas de inversión en admin

### DIFF
--- a/app/components/custom/admin/budget_investments/investments_component.html.erb
+++ b/app/components/custom/admin/budget_investments/investments_component.html.erb
@@ -11,7 +11,7 @@
     <h3 class="inline-block"><%= page_entries_info investments %></h3>
     <%= render "admin/shared/columns_selector",
                cookie: "investments-columns",
-               default: %w[id title supports votes admin valuator geozone feasibility price valuation_finished visible_to_valuators selected incompatible] %>
+               default: %w[id title created_at supports votes admin valuator geozone feasibility price valuation_finished visible_to_valuators selected incompatible] %>
     <br>
 
     <%= render "filters_description", i18n_namespace: "admin.budget_investments.index" %>
@@ -21,6 +21,7 @@
         <tr>
           <th><%= link_to_investments_sorted_by :id %></th>
           <th data-field="title"><%= link_to_investments_sorted_by :title %></th>
+          <th data-field="created_at"><%= link_to_investments_sorted_by :created_at %></th>
           <th data-field="supports"><%= link_to_investments_sorted_by :supports %></th>
           <th data-field="ballots"><%= link_to_investments_sorted_by :ballots %></th>
           <th data-field="admin"><%= t("admin.budget_investments.index.list.admin") %></th>

--- a/app/components/custom/admin/budget_investments/investments_component.html.erb
+++ b/app/components/custom/admin/budget_investments/investments_component.html.erb
@@ -1,0 +1,65 @@
+<div id="investments" class="admin-budget-investments">
+  <%= link_to t("admin.budget_investments.index.download_current_selection"),
+              admin_budget_budget_investments_path(csv_params),
+              class: "float-right small clear" %>
+
+  <% if params[:advanced_filters].include?("winners") %>
+    <%= render Admin::Budgets::CalculateWinnersButtonComponent.new(budget, from_investments: true) %>
+  <% end %>
+
+  <% if investments.any? %>
+    <h3 class="inline-block"><%= page_entries_info investments %></h3>
+    <%= render "admin/shared/columns_selector",
+               cookie: "investments-columns",
+               default: %w[id title supports votes admin valuator geozone feasibility price valuation_finished visible_to_valuators selected incompatible] %>
+    <br>
+
+    <%= render "filters_description", i18n_namespace: "admin.budget_investments.index" %>
+
+    <table class="table-for-mobile column-selectable">
+      <thead>
+        <tr>
+          <th><%= link_to_investments_sorted_by :id %></th>
+          <th data-field="title"><%= link_to_investments_sorted_by :title %></th>
+          <th data-field="supports"><%= link_to_investments_sorted_by :supports %></th>
+          <th data-field="ballots"><%= link_to_investments_sorted_by :ballots %></th>
+          <th data-field="admin"><%= t("admin.budget_investments.index.list.admin") %></th>
+          <th data-field="author">
+            <%= t("admin.budget_investments.index.list.author") %>
+          </th>
+          <th data-field="valuator">
+            <%= t("admin.budget_investments.index.list.valuation_group") %> /
+            <%= t("admin.budget_investments.index.list.valuator") %>
+          </th>
+          <th data-field="geozone"><%= t("admin.budget_investments.index.list.geozone") %></th>
+          <th data-field="feasibility"><%= t("admin.budget_investments.index.list.feasibility") %></th>
+          <% if budget.show_money? %>
+            <th data-field="price"><%= t("admin.budget_investments.index.list.price") %></th>
+          <% end %>
+          <th data-field="valuation_finished">
+            <%= t("admin.budget_investments.index.list.valuation_finished") %>
+          </th>
+          <th data-field="visible_to_valuators">
+            <%= t("admin.budget_investments.index.list.visible_to_valuators") %>
+          </th>
+          <th data-field="selected"><%= t("admin.budget_investments.index.list.selected") %></th>
+          <% if params[:advanced_filters]&.include?("selected") %>
+            <th data-field="incompatible"><%= t("admin.budget_investments.index.list.incompatible") %></th>
+          <% end %>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% investments.each do |investment| %>
+          <%= render Admin::BudgetInvestments::RowComponent.new(investment) %>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= paginate investments %>
+  <% else %>
+    <div class="callout primary clear">
+      <%= t("admin.budget_investments.index.no_budget_investments") %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/custom/admin/budget_investments/investments_component.rb
+++ b/app/components/custom/admin/budget_investments/investments_component.rb
@@ -1,0 +1,7 @@
+class Admin::BudgetInvestments::InvestmentsComponent < ApplicationComponent; end
+
+load Rails.root.join("app", "components", "admin", "budget_investments", "investments_component.rb")
+
+class Admin::BudgetInvestments::InvestmentsComponent
+  # Only template customizations
+end

--- a/app/components/custom/admin/budget_investments/row_component.html.erb
+++ b/app/components/custom/admin/budget_investments/row_component.html.erb
@@ -1,0 +1,61 @@
+<tr id="<%= dom_id(investment) %>" class="budget_investment">
+  <td class="text-right" data-field="id">
+    <strong><%= investment.id %></strong>
+  </td>
+
+  <td data-field="title">
+    <%= link_to investment.title, investment_path, target: "_blank" %>
+  </td>
+
+  <td data-field="supports">
+    <%= investment.total_votes %>
+  </td>
+
+  <td data-field="ballots">
+    <%= investment.ballot_lines_count %>
+  </td>
+
+  <td data-field="admin">
+    <%= administrator_info %>
+  </td>
+
+  <td data-field="author">
+    <%= investment.author.name %>
+  </td>
+
+  <td data-field="valuator">
+    <%= valuators_info %>
+  </td>
+
+  <td data-field="geozone">
+    <%= investment.heading.name %>
+  </td>
+
+  <td data-field="feasibility">
+    <%= t("admin.budget_investments.index.feasibility.#{investment.feasibility}") %>
+  </td>
+
+  <% if budget.show_money? %>
+    <td data-field="price">
+      <%= investment.formatted_price %>
+    </td>
+  <% end %>
+
+  <td data-field="valuation_finished">
+    <%= investment.valuation_finished? ? t("shared.yes") : t("shared.no") %>
+  </td>
+
+  <td data-field="visible_to_valuators">
+    <%= render Admin::BudgetInvestments::ToggleVisibleToValuatorsComponent.new(investment) %>
+  </td>
+
+  <td data-field="selected">
+    <%= render Admin::BudgetInvestments::ToggleSelectionComponent.new(investment) %>
+  </td>
+
+  <% if params[:advanced_filters]&.include?("selected") %>
+    <td data-field="incompatible">
+      <%= investment.incompatible? ? t("shared.yes") : t("shared.no") %>
+    </td>
+  <% end %>
+</tr>

--- a/app/components/custom/admin/budget_investments/row_component.html.erb
+++ b/app/components/custom/admin/budget_investments/row_component.html.erb
@@ -7,6 +7,10 @@
     <%= link_to investment.title, investment_path, target: "_blank" %>
   </td>
 
+  <td data-field="created_at">
+    <%= l investment.created_at, format: :datetime %>
+  </td>
+
   <td data-field="supports">
     <%= investment.total_votes %>
   </td>

--- a/app/components/custom/admin/budget_investments/row_component.rb
+++ b/app/components/custom/admin/budget_investments/row_component.rb
@@ -1,0 +1,7 @@
+class Admin::BudgetInvestments::RowComponent < ApplicationComponent; end
+
+load Rails.root.join("app", "components", "admin", "budget_investments", "row_component.rb")
+
+class Admin::BudgetInvestments::RowComponent
+  # Only template customizations
+end

--- a/app/components/custom/admin/budget_investments/search_form_component.html.erb
+++ b/app/components/custom/admin/budget_investments/search_form_component.html.erb
@@ -18,6 +18,14 @@
         <% end %>
         <div>
           <div class="filter">
+            <%= label_tag :created_before, t("admin.budget_investments.index.filters.created_before") %>
+            <%= text_field_tag :created_before, params["created_before"], placeholder: t("admin.budget_investments.index.created_before_filter") %>
+          </div>
+          <div class="filter">
+            <%= label_tag :created_after, t("admin.budget_investments.index.filters.created_after") %>
+            <%= text_field_tag :created_after, params["created_after"], placeholder: t("admin.budget_investments.index.created_after_filter") %>
+          </div>
+          <div class="filter">
             <%= label_tag :min_total_supports, t("admin.budget_investments.index.filters.min_total_supports") %>
             <%= text_field_tag :min_total_supports, params["min_total_supports"] %>
           </div>

--- a/app/components/custom/admin/budget_investments/search_form_component.html.erb
+++ b/app/components/custom/admin/budget_investments/search_form_component.html.erb
@@ -19,19 +19,19 @@
         <div>
           <div class="filter">
             <%= label_tag :created_before, t("admin.budget_investments.index.filters.created_before") %>
-            <%= text_field_tag :created_before, params["created_before"], placeholder: t("admin.budget_investments.index.created_before_filter") %>
+            <%= text_field_tag :created_before, params["created_before"], placeholder: t("admin.budget_investments.index.created_before_filter"), autocomplete: "off" %>
           </div>
           <div class="filter">
             <%= label_tag :created_after, t("admin.budget_investments.index.filters.created_after") %>
-            <%= text_field_tag :created_after, params["created_after"], placeholder: t("admin.budget_investments.index.created_after_filter") %>
+            <%= text_field_tag :created_after, params["created_after"], placeholder: t("admin.budget_investments.index.created_after_filter"), autocomplete: "off" %>
           </div>
           <div class="filter">
             <%= label_tag :min_total_supports, t("admin.budget_investments.index.filters.min_total_supports") %>
-            <%= text_field_tag :min_total_supports, params["min_total_supports"] %>
+            <%= text_field_tag :min_total_supports, params["min_total_supports"], autocomplete: "off" %>
           </div>
           <div class="filter">
             <%= label_tag :max_total_supports, t("admin.budget_investments.index.filters.max_total_supports") %>
-            <%= text_field_tag :max_total_supports, params["max_total_supports"] %>
+            <%= text_field_tag :max_total_supports, params["max_total_supports"], autocomplete: "off" %>
           </div>
         </div>
       </div>

--- a/app/components/custom/admin/budget_investments/search_form_component.html.erb
+++ b/app/components/custom/admin/budget_investments/search_form_component.html.erb
@@ -1,0 +1,78 @@
+<%= form_tag(admin_budget_budget_investments_path(budget), method: :get, enforce_utf8: false, class: "admin-budget-investments-search-form") do %>
+  <div class="small-12 column">
+    <%= button_tag t("admin.budget_investments.index.advanced_filters"),
+                   type: :button,
+                   data: { toggle: "advanced_filters" },
+                   class: "advanced-filters" %>
+  </div>
+
+  <div id="advanced_filters" class="<%= advanced_menu_visibility %>" data-toggler=".hide">
+    <div class="small-12 column">
+      <div class="advanced-filters-content">
+        <% %w[feasible selected undecided unfeasible without_admin without_valuator under_valuation
+              valuation_finished winners with_comments without_comments].each do |filter| %>
+          <div class="filter">
+            <%= check_box_tag "advanced_filters[]", filter, advanced_filters_params.index(filter), id: "advanced_filters_#{filter}" %>
+            <%= label_tag "advanced_filters[#{filter}]", t("admin.budget_investments.index.filters.#{filter}") %>
+          </div>
+        <% end %>
+        <div>
+          <div class="filter">
+            <%= label_tag :min_total_supports, t("admin.budget_investments.index.filters.min_total_supports") %>
+            <%= text_field_tag :min_total_supports, params["min_total_supports"] %>
+          </div>
+          <div class="filter">
+            <%= label_tag :max_total_supports, t("admin.budget_investments.index.filters.max_total_supports") %>
+            <%= text_field_tag :max_total_supports, params["max_total_supports"] %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="basic-filters">
+    <div class="filter">
+      <%= label_tag :administrator_id, attribute_name(:administrator_id) %>
+      <%= select_tag :administrator_id,
+                     options_for_select(admin_select_options, params[:administrator_id]),
+                     { prompt: t("admin.budget_investments.index.administrator_filter_all") } %>
+    </div>
+
+    <div class="filter">
+      <%= label_tag :valuator_or_group_id, t("admin.budget_investments.index.basic_filters.valuator_or_group") %>
+      <%= select_tag :valuator_or_group_id,
+                     options_for_select(valuator_or_group_select_options, params[:valuator_or_group_id]),
+                     { prompt: t("admin.budget_investments.index.valuator_filter_all") } %>
+    </div>
+
+    <div class="filter">
+      <%= label_tag :heading_id, attribute_name(:heading_id) %>
+      <%= select_tag :heading_id,
+                     options_for_select(budget_heading_select_options(budget), params[:heading_id]),
+                     { prompt: t("admin.budget_investments.index.heading_filter_all") } %>
+    </div>
+
+    <div class="filter">
+      <%= label_tag :tag_name, attribute_name(:valuation_tag_list) %>
+      <%= select_tag :tag_name,
+                     options_for_select(investment_tags_select_options("valuation_tags"), params[:tag_name]),
+                     { prompt: t("admin.budget_investments.index.tags_filter_all") } %>
+    </div>
+
+    <div class="filter">
+      <%= label_tag :milestone_tag_name, attribute_name(:milestone_tag_list) %>
+      <%= select_tag :milestone_tag_name,
+                     options_for_select(investment_tags_select_options("milestone_tags"), params[:milestone_tag_name]),
+                     { prompt: t("admin.budget_investments.index.milestone_tags_filter_all") } %>
+    </div>
+
+    <div class="filter title-or-id-filter">
+      <%= label_tag :title_or_id, t("admin.budget_investments.index.basic_filters.title_or_id") %>
+      <%= text_field_tag :title_or_id, params["title_or_id"] %>
+    </div>
+
+    <div class="filter">
+      <%= submit_tag t("admin.budget_investments.index.buttons.filter"), class: "button expanded" %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/custom/admin/budget_investments/search_form_component.html.erb
+++ b/app/components/custom/admin/budget_investments/search_form_component.html.erb
@@ -76,7 +76,7 @@
 
     <div class="filter title-or-id-filter">
       <%= label_tag :title_or_id, t("admin.budget_investments.index.basic_filters.title_or_id") %>
-      <%= text_field_tag :title_or_id, params["title_or_id"] %>
+      <%= text_field_tag :title_or_id, params["title_or_id"], autocomplete: "off" %>
     </div>
 
     <div class="filter">

--- a/app/components/custom/admin/budget_investments/search_form_component.rb
+++ b/app/components/custom/admin/budget_investments/search_form_component.rb
@@ -4,7 +4,9 @@ load Rails.root.join("app", "components", "admin", "budget_investments", "search
 
 class Admin::BudgetInvestments::SearchFormComponent
   # Filter by created before and after
+
   private
+
     def advanced_menu_visibility
       if advanced_filters_params.empty? &&
          params["created_before"].blank? &&

--- a/app/components/custom/admin/budget_investments/search_form_component.rb
+++ b/app/components/custom/admin/budget_investments/search_form_component.rb
@@ -1,0 +1,7 @@
+class Admin::BudgetInvestments::SearchFormComponent < ApplicationComponent; end
+
+load Rails.root.join("app", "components", "admin", "budget_investments", "search_form_component.rb")
+
+class Admin::BudgetInvestments::SearchFormComponent
+  # Only template customizations
+end

--- a/app/components/custom/admin/budget_investments/search_form_component.rb
+++ b/app/components/custom/admin/budget_investments/search_form_component.rb
@@ -3,5 +3,17 @@ class Admin::BudgetInvestments::SearchFormComponent < ApplicationComponent; end
 load Rails.root.join("app", "components", "admin", "budget_investments", "search_form_component.rb")
 
 class Admin::BudgetInvestments::SearchFormComponent
-  # Only template customizations
+  # Filter by created before and after
+  private
+    def advanced_menu_visibility
+      if advanced_filters_params.empty? &&
+         params["created_before"].blank? &&
+         params["created_after"].blank? &&
+         params["min_total_supports"].blank? &&
+         params["max_total_supports"].blank?
+        "hide"
+      else
+        ""
+      end
+    end
 end

--- a/app/models/custom/budget/investment.rb
+++ b/app/models/custom/budget/investment.rb
@@ -5,6 +5,20 @@ class Budget
     # Add sort by ballots
     SORTING_OPTIONS = { id: "id", supports: "cached_votes_up", ballots: "ballot_lines_count" }.freeze
 
+    # Add created before and after filters
+    scope :by_created_after,            ->(date)    { where("budget_investments.created_at >= ?", date) }
+    scope :by_created_before,           ->(date)    { where("budget_investments.created_at <= ?", date) }
+
+    class <<self
+      alias_method :consul_scoped_filter, :scoped_filter
+    end
+
+    def self.scoped_filter(params, current_filter)
+      results = consul_scoped_filter(params, current_filter)
+      results = results.by_created_before(params[:created_before]) if params[:created_before].present?
+      results = results.by_created_after(params[:created_after]) if params[:created_after].present?
+      results
+    end
 
     def self.advanced_filters(params, results)
       # Add filter by comments

--- a/app/models/custom/budget/investment.rb
+++ b/app/models/custom/budget/investment.rb
@@ -1,0 +1,7 @@
+load Rails.root.join("app", "models", "budget", "investment.rb")
+
+class Budget
+  class Investment
+    SORTING_OPTIONS = { id: "id", supports: "cached_votes_up", ballots: "ballot_lines_count" }.freeze
+  end
+end

--- a/app/models/custom/budget/investment.rb
+++ b/app/models/custom/budget/investment.rb
@@ -3,7 +3,7 @@ load Rails.root.join("app", "models", "budget", "investment.rb")
 class Budget
   class Investment
     # Add sort by ballots
-    SORTING_OPTIONS = { id: "id", supports: "cached_votes_up", ballots: "ballot_lines_count" }.freeze
+    SORTING_OPTIONS = { id: "id", created_at: "created_at", supports: "cached_votes_up", ballots: "ballot_lines_count" }.freeze
 
     # Add created before and after filters
     scope :by_created_after,            ->(date)    { where("budget_investments.created_at >= ?", date) }

--- a/app/models/custom/budget/investment.rb
+++ b/app/models/custom/budget/investment.rb
@@ -2,6 +2,27 @@ load Rails.root.join("app", "models", "budget", "investment.rb")
 
 class Budget
   class Investment
+    # Add sort by ballots
     SORTING_OPTIONS = { id: "id", supports: "cached_votes_up", ballots: "ballot_lines_count" }.freeze
+
+
+    def self.advanced_filters(params, results)
+      # Add filter by comments
+      results = results.without_admin      if params[:advanced_filters].include?("without_admin")
+      results = results.without_valuator   if params[:advanced_filters].include?("without_valuator")
+      results = results.under_valuation    if params[:advanced_filters].include?("under_valuation")
+      results = results.valuation_finished if params[:advanced_filters].include?("valuation_finished")
+      results = results.winners            if params[:advanced_filters].include?("winners")
+
+      ids = []
+      ids += results.valuation_finished_feasible.ids if params[:advanced_filters].include?("feasible")
+      ids += results.where(selected: true).ids       if params[:advanced_filters].include?("selected")
+      ids += results.undecided.ids                   if params[:advanced_filters].include?("undecided")
+      ids += results.unfeasible.ids                  if params[:advanced_filters].include?("unfeasible")
+      ids += results.where("comments_count > 0").ids if params[:advanced_filters].include?('with_comments')
+      ids += results.where("comments_count = 0").ids if params[:advanced_filters].include?('without_comments')
+      results = results.where(id: ids) if ids.any?
+      results
+    end
   end
 end

--- a/app/models/custom/budget/investment.rb
+++ b/app/models/custom/budget/investment.rb
@@ -3,13 +3,16 @@ load Rails.root.join("app", "models", "budget", "investment.rb")
 class Budget
   class Investment
     # Add sort by ballots
-    SORTING_OPTIONS = { id: "id", created_at: "created_at", supports: "cached_votes_up", ballots: "ballot_lines_count" }.freeze
+    SORTING_OPTIONS = { id: "id",
+                        created_at: "created_at",
+                        supports: "cached_votes_up",
+                        ballots: "ballot_lines_count" }.freeze
 
     # Add created before and after filters
-    scope :by_created_after,            ->(date)    { where("budget_investments.created_at >= ?", date) }
-    scope :by_created_before,           ->(date)    { where("budget_investments.created_at <= ?", date) }
+    scope :by_created_after,            ->(date)    { where(budget_investments: { created_at: date.. }) }
+    scope :by_created_before,           ->(date)    { where(budget_investments: { created_at: ..date }) }
 
-    class <<self
+    class << self
       alias_method :consul_scoped_filter, :scoped_filter
     end
 
@@ -33,8 +36,8 @@ class Budget
       ids += results.where(selected: true).ids       if params[:advanced_filters].include?("selected")
       ids += results.undecided.ids                   if params[:advanced_filters].include?("undecided")
       ids += results.unfeasible.ids                  if params[:advanced_filters].include?("unfeasible")
-      ids += results.where("comments_count > 0").ids if params[:advanced_filters].include?('with_comments')
-      ids += results.where("comments_count = 0").ids if params[:advanced_filters].include?('without_comments')
+      ids += results.where("comments_count > 0").ids if params[:advanced_filters].include?("with_comments")
+      ids += results.where("comments_count = 0").ids if params[:advanced_filters].include?("without_comments")
       results = results.where(id: ids) if ids.any?
       results
     end

--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -1,0 +1,14 @@
+es:
+  admin:
+    budget_investments:
+      index:
+        created_before_filter: YYYY-MM-DD
+        created_after_filter: YYYY-MM-DD
+        filters:
+          created_before: Created before
+          created_after: Created after
+          with_comments: With comments
+          without_comments: Without comments
+        list:
+          ballots: Ballots
+          created_at: Created at

--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -1,4 +1,4 @@
-es:
+en:
   admin:
     budget_investments:
       index:

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -2,5 +2,8 @@ es:
   admin:
     budget_investments:
       index:
+        filters:
+          with_comments: Con comentarios
+          without_comments: Sin comentarios
         list:
           ballots: Votos

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -11,3 +11,4 @@ es:
           without_comments: Sin comentarios
         list:
           ballots: Votos
+          created_at: Fecha de creación

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -1,0 +1,6 @@
+es:
+  admin:
+    budget_investments:
+      index:
+        list:
+          ballots: Votos

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -2,7 +2,11 @@ es:
   admin:
     budget_investments:
       index:
+        created_before_filter: YYYY-MM-DD
+        created_after_filter: YYYY-MM-DD
         filters:
+          created_before: Creada antes de
+          created_after: Creada después de
           with_comments: Con comentarios
           without_comments: Sin comentarios
         list:

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -2,5 +2,8 @@ val:
   admin:
     budget_investments:
       index:
+        filters:
+          with_comments: Amb comentaris
+          without_comments: Sense comentaris
         list:
           ballots: Vots

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -11,3 +11,4 @@ val:
           without_comments: Sense comentaris
         list:
           ballots: Vots
+          created_at: Data de creació

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -2,7 +2,11 @@ val:
   admin:
     budget_investments:
       index:
+        created_before_filter: YYYY-MM-DD
+        created_after_filter: YYYY-MM-DD
         filters:
+          created_before: Creada abans de
+          created_after: Creada després de
           with_comments: Amb comentaris
           without_comments: Sense comentaris
         list:

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -1,0 +1,6 @@
+val:
+  admin:
+    budget_investments:
+      index:
+        list:
+          ballots: Vots

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -1755,7 +1755,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_content(investment.title)
     end
 
-    scenario "Set cookie with default columns value if undefined" do
+    scenario "Set cookie with default columns value if undefined", :consul do
       visit admin_budget_budget_investments_path(budget)
 
       cookie_value = cookie_by_name("investments-columns")[:value]
@@ -1794,7 +1794,7 @@ describe "Admin budget investments", :admin do
       end
     end
 
-    scenario "Cookie will be updated after change columns selection" do
+    scenario "Cookie will be updated after change columns selection", :consul do
       visit admin_budget_budget_investments_path(budget)
 
       click_button "Columns"

--- a/spec/system/custom/admin/budget_investments_spec.rb
+++ b/spec/system/custom/admin/budget_investments_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe "Admin budget investments", :admin do
+  let(:budget) { create(:budget) }
+  let(:administrator) do
+    create(:administrator, user: create(:user, username: "Ana", email: "ana@admins.org"))
+  end
+  context "Columns chooser" do
+    scenario "Set cookie with default columns value if undefined", :consul do
+      visit admin_budget_budget_investments_path(budget)
+
+      cookie_value = cookie_by_name("investments-columns")[:value]
+
+      expect(cookie_value).to eq("id,title,created_at,supports,votes,admin,geozone,feasibility," \
+                                 "price,valuation_finished,visible_to_valuators,selected,incompatible")
+    end
+
+    scenario "Cookie will be updated after change columns selection", :consul do
+      visit admin_budget_budget_investments_path(budget)
+
+      click_button "Columns"
+
+      expect(page).to have_css "button[aria-expanded=true]", exact_text: "Columns"
+
+      within("#js-columns-selector-wrapper") do
+        uncheck "Title"
+        uncheck "Price"
+        uncheck "Valuation Group / Valuator"
+        uncheck "Created at"
+        check "Author"
+      end
+
+      cookie_value = cookie_by_name("investments-columns")[:value]
+
+      expect(cookie_value).to eq("id,supports,votes,admin,geozone,feasibility," \
+                                 "valuation_finished,visible_to_valuators,selected,incompatible,author")
+
+      refresh
+
+      expect(page).to have_css "button[aria-expanded=false]", exact_text: "Columns"
+
+      cookie_value = cookie_by_name("investments-columns")[:value]
+
+      expect(cookie_value).to eq("id,created_at,supports,votes,admin,geozone,feasibility," \
+                                 "valuation_finished,visible_to_valuators,selected,incompatible,author")
+    end
+  end
+end


### PR DESCRIPTION
## Objectives

Permitir filtrar propuestas por fecha de creación y las que tienen comentarios o las que no.
Mostrar columnas de fecha de creación y votos.

## Visual Changes

La parte pública queda igual, en el listado de propuestas de un presupuesto participativo en admin hay nuevos filtros avanzados y la opción de mostrar más columnas.