### PR TITLE
chore: replace knapsack with custom sharding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ permissions:
 
 env:
   TEST_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && 1 || '' }}
+  SPEC_FILE_REGEX: ${{ vars.SPEC_FILE_REGEX || '' }}
+  SPEC_FILE_LIST: ${{ vars.SPEC_FILE_LIST || '' }}
 
 jobs:
   tests:
@@ -62,14 +64,63 @@ jobs:
         run: bundle exec rake db:setup
       - name: Compile assets
         run: bundle exec rake assets:precompile > /dev/null 2>&1
-      - name: Run test suite
+      - name: Run budget specs shard
         env:
-          KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
-          KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
-          KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-          KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
-          KNAPSACK_PRO_LOG_LEVEL: info
-        run: bin/knapsack_pro_rspec
+          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+          SPEC_FILE_REGEX: ${{ env.SPEC_FILE_REGEX }}
+          SPEC_FILE_LIST: ${{ env.SPEC_FILE_LIST }}
+        run: |
+          set -euo pipefail
+
+          SPEC_FILE_REGEX_LC="$(printf '%s' "${SPEC_FILE_REGEX:-}" | tr '[:upper:]' '[:lower:]')"
+
+          SYSTEM_TMP="$(mktemp)"
+          OTHER_TMP="$(mktemp)"
+          ALL_TMP="$(mktemp)"
+          trap 'rm -f "$SYSTEM_TMP" "$OTHER_TMP" "$ALL_TMP"' EXIT
+
+          if [ -n "${SPEC_FILE_LIST:-}" ]; then
+            printf '%s\n' "$SPEC_FILE_LIST" |
+              tr ' ' '\n' |
+              awk 'NF > 0' |
+              awk '/_spec\.rb$/ { print }' |
+              sort -u > "$ALL_TMP"
+          elif [ -n "$SPEC_FILE_REGEX_LC" ]; then
+            find spec -type f -name '*_spec.rb' |
+              sort |
+              awk -v spec_re="$SPEC_FILE_REGEX_LC" 'tolower($0) ~ spec_re' > "$ALL_TMP"
+          else
+            find spec -type f -name '*_spec.rb' |
+              sort > "$ALL_TMP"
+          fi
+
+          awk '/^spec\/system\// { print }' "$ALL_TMP" |
+            awk -v total="$CI_NODE_TOTAL" -v shard_idx="$CI_NODE_INDEX" '((NR - 1) % total) == shard_idx' > "$SYSTEM_TMP"
+
+          awk '$0 !~ /^spec\/system\// { print }' "$ALL_TMP" |
+            awk -v total="$CI_NODE_TOTAL" -v shard_idx="$CI_NODE_INDEX" '((NR - 1) % total) == shard_idx' > "$OTHER_TMP"
+
+          mapfile -t SYSTEM_SHARD_FILES < "$SYSTEM_TMP"
+          mapfile -t OTHER_SHARD_FILES < "$OTHER_TMP"
+
+          SHARD_FILES=("${SYSTEM_SHARD_FILES[@]}" "${OTHER_SHARD_FILES[@]}")
+
+          if [ ${#SHARD_FILES[@]} -eq 0 ]; then
+            echo "No specs assigned to shard ${CI_NODE_INDEX}/${CI_NODE_TOTAL}"
+            exit 0
+          fi
+
+          SEED=$(( (${GITHUB_RUN_NUMBER:-1} * 100) + CI_NODE_INDEX + 1 ))
+          echo "SPEC_FILE_REGEX=${SPEC_FILE_REGEX:-}"
+          if [ -n "${SPEC_FILE_LIST:-}" ]; then
+            echo "SPEC_FILE_LIST provided"
+          elif [ -z "${SPEC_FILE_REGEX:-}" ]; then
+            echo "SPEC_FILE_REGEX and SPEC_FILE_LIST empty: running full suite"
+          fi
+          echo "Running ${#SYSTEM_SHARD_FILES[@]} system specs and ${#OTHER_SHARD_FILES[@]} non-system specs on shard ${CI_NODE_INDEX}/${CI_NODE_TOTAL} with seed ${SEED}"
+
+          bundle exec rspec --order random --seed "$SEED" --format documentation "${SHARD_FILES[@]}"
       - name: Coveralls Parallel
         if: ${{ env.TEST_COVERAGE == 1 }}
         uses: coverallsapp/github-action@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,9 +95,28 @@ jobs:
               sort > "$ALL_TMP"
           fi
 
+          # System specs: greedy LPT bin-packing weighted by example count
           awk '/^spec\/system\// { print }' "$ALL_TMP" |
-            awk -v total="$CI_NODE_TOTAL" -v shard_idx="$CI_NODE_INDEX" '((NR - 1) % total) == shard_idx' > "$SYSTEM_TMP"
+            ruby -e '
+              total     = ENV["CI_NODE_TOTAL"].to_i
+              shard_idx = ENV["CI_NODE_INDEX"].to_i
+              files     = $stdin.read.split("\n").reject(&:empty?)
+              counts    = files.map do |f|
+                            count = File.read(f).scan(/^\s*(it|scenario|specify)\b/).size
+                            [f, count]
+                          end
+              counts.sort_by! { |_, c| -c }
+              shards     = Array.new(total, 0)
+              assignment = []
+              counts.each do |file, count|
+                min_shard = shards.each_with_index.min_by { |v, _| v }[1]
+                assignment << [file, min_shard]
+                shards[min_shard] += count
+              end
+              assignment.select { |_, s| s == shard_idx }.each { |f, _| puts f }
+            ' > "$SYSTEM_TMP"
 
+          # Non-system specs: simple round-robin (fast, file count is balanced enough)
           awk '$0 !~ /^spec\/system\// { print }' "$ALL_TMP" |
             awk -v total="$CI_NODE_TOTAL" -v shard_idx="$CI_NODE_INDEX" '((NR - 1) % total) == shard_idx' > "$OTHER_TMP"
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ tmp/
 # Test results
 /spec/examples.txt
 /coverage/
+
+# Ignore inner worktrees
+/.worktrees/*


### PR DESCRIPTION
### Motivation

The project does not have a Knapsack Pro license. The previous CI setup relied on `bin/knapsack_pro_rspec`, which required a paid API token to distribute tests across nodes. Without it, the build takes an hour or so.

## Objectives
Reduce the time needed to run the test suite by executing a subset of specs controlled via GitHub Actions Repository Variables.

## Algoritmo de sharding

#### Fase 1 — Selección del conjunto de ficheros

Antes de repartir, se determina qué ficheros entran en el pool:

| Condición | Comportamiento |
|---|---|
| `SPEC_FILE_LIST` tiene valor | Se usa esa lista explícita de rutas (espacio-separadas). |
| `SPEC_FILE_REGEX` tiene valor | Se buscan todos los `*_spec.rb` bajo `spec/` y se filtran por regex sobre el path. |
| Ambas vacías | Se recogen **todos** los `*_spec.rb` bajo `spec/`. |

El resultado queda ordenado alfabéticamente en `ALL_TMP`.

---

#### Fase 2 — Specs de sistema (`spec/system/`) → LPT greedy bin-packing

Es el grupo más lento, por lo que se usa un algoritmo **weighted**:

1. **Conteo**: para cada fichero se cuenta el número de ejemplos definidos (líneas que contienen `it`, `scenario` o `specify`).
2. **Orden descendente**: los ficheros se ordenan de mayor a menor peso (LPT — Longest Processing Time first).
3. **Asignación greedy**: se mantiene un contador de carga por shard. Cada fichero se asigna al shard con **menor carga acumulada** en ese momento.

Ejemplo con 5 shards y ficheros de tamaños `[80, 70, 60, 50, 40, 30]`:

```
Assign 80 → shard 0  → [80,  0,  0,  0,  0]
Assign 70 → shard 1  → [80, 70,  0,  0,  0]
Assign 60 → shard 2  → [80, 70, 60,  0,  0]
Assign 50 → shard 3  → [80, 70, 60, 50,  0]
Assign 40 → shard 4  → [80, 70, 60, 50, 40]
Assign 30 → shard 3  → [80, 70, 60, 80, 40]  ← va al shard con menos carga
```

Resultado: cargas `[80, 70, 60, 80, 40]` vs round-robin `[110, 100, 80, 0, 0]`.

---

#### Fase 3 — Specs no-sistema → Round-robin

Modelos, controllers, helpers, components, etc. son rápidos e individuales, por lo que un **round-robin por índice de fichero** es suficiente y más simple:

```
fichero_nro % total_nodos == índice_nodo_actual
```

Con 469 ficheros y 5 nodos: cada nodo recibe exactamente 93 o 94 ficheros.

---

#### Fase 4 — Ejecución

Cada nodo ejecuta su shard con:

```bash
bundle exec rspec --order random --seed "$SEED" --format documentation "${SHARD_FILES[@]}"
```

- Orden aleatorio con seed reproducible: `(run_number × 100) + node_index + 1`.
- Si el shard queda vacío (por ejemplo con un regex muy restrictivo), el nodo sale con código 0 sin lanzar RSpec.
