### PR TITLE
chore: script para backups

### DIFF
--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -1,4 +1,4 @@
 set :branch, ENV["branch"] || :stable
 
 server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]
-server deploysecret(:server2), user: deploysecret(:user), roles: %w[web app db importer cron background]
+server deploysecret(:server2), user: deploysecret(:user), roles: %w[web app db importer background]

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,6 @@
 set :branch, ENV["branch"] || :stable
 
-server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]
+server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background backup]
 server deploysecret(:server2), user: deploysecret(:user), roles: %w[web app db importer background]
 #server deploysecret(:server3), user: deploysecret(:user), roles: %w(web app db importer)
 #server deploysecret(:server4), user: deploysecret(:user), roles: %w(web app db importer)

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,6 @@
 set :branch, ENV["branch"] || :stable
 
 server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]
-server deploysecret(:server2), user: deploysecret(:user), roles: %w[web app db importer cron background]
+server deploysecret(:server2), user: deploysecret(:user), roles: %w[web app db importer background]
 #server deploysecret(:server3), user: deploysecret(:user), roles: %w(web app db importer)
 #server deploysecret(:server4), user: deploysecret(:user), roles: %w(web app db importer)

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -35,6 +35,18 @@ every 1.day, at: "3:00 am", roles: [:cron] do
   rake "votes:reset_hot_score"
 end
 
+every 1.day, at: "4:10 am", roles: [:cron] do
+  command "/bin/bash #{@path}/create_backup.sh -t day"
+end
+
+every :sunday, at: "4:20 am", roles: [:cron] do
+  command "/bin/bash #{@path}/create_backup.sh -t week"
+end
+
+every 1.month, at: "4:30 am", roles: [:cron] do
+  command "/bin/bash #{@path}/create_backup.sh -t month"
+end
+
 every :reboot do
   # Number of workers must be kept in sync with capistrano's delayed_job_workers
   command "cd #{@path} && RAILS_ENV=#{@environment} bundle exec bin/delayed_job -m -n 2 restart"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -35,15 +35,15 @@ every 1.day, at: "3:00 am", roles: [:cron] do
   rake "votes:reset_hot_score"
 end
 
-every 1.day, at: "4:10 am", roles: [:cron] do
+every 1.day, at: "4:10 am", roles: [:backup] do
   command "/bin/bash #{@path}/create_backup.sh -t day"
 end
 
-every :sunday, at: "4:20 am", roles: [:cron] do
+every :sunday, at: "4:20 am", roles: [:backup] do
   command "/bin/bash #{@path}/create_backup.sh -t week"
 end
 
-every 1.month, at: "4:30 am", roles: [:cron] do
+every 1.month, at: "4:30 am", roles: [:backup] do
   command "/bin/bash #{@path}/create_backup.sh -t month"
 end
 

--- a/create_backup.sh
+++ b/create_backup.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Este script necesita que el client de minio tenga un alias que apunte al bucket de valencia
+# Por ejemplo habiendo ejecutado este comando anteriormente: mc alias set valencia https://s3.gra.io.cloud.ovh.net/ user pass
+#
+# También necesita que el usuario que ejecuta el script tenga la clave pública de seguridad@osoigo.com
+#   gpg --import seguridad.gpg.pub
+
+export PATH=$PATH:/usr/local/bin
+
+usage() {
+  echo "Usage: $0 [-t <day|month|week>] backup_name" 1>&2
+  exit 1
+}
+
+encrypt() {
+  path=$1
+  gpg --batch --yes --encrypt --recipient seguridad@osoigo.com --trust-model always $path
+  rm -f $path
+}
+
+clean_old_local_backups() {
+  path=$1
+  keep=$2
+  # Borrar backups viejos en local
+  cd $path
+  backups=($(ls -r))
+  for item in ${backups[@]:${keep}}; do
+    find $item -type f -exec shred -u {} \;
+    rm -rf $item
+  done
+}
+
+clean_old_remote_backups() {
+  path=$1
+  keep=$2
+  # Borrar backups viejos en el almacenamiento S3
+  backups=($(mcli ls --json ${path} | jq -r ".key" | sort -n -r))
+  for item in ${backups[@]:${keep}}; do
+    mcli rm -r -q --force ${path}/${item}
+  done
+}
+
+get_database_field() {
+  file=$1
+  field=$2
+
+  value=$(grep $field $file | cut -d: -f2)
+  # remove leading whitespace characters
+  value="${value#"${value%%[![:space:]]*}"}"
+  # remove trailing whitespace characters
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+set -e
+while getopts "t:" o; do
+  case "${o}" in
+  t)
+    BACKUP_TYPE=${OPTARG}
+    [ "$BACKUP_TYPE" == "day" ] || [ "$BACKUP_TYPE" == "month" ] || [ "$BACKUP_TYPE" == "week" ] || usage
+    ;;
+  esac
+done
+
+shift $(($OPTIND - 1))
+
+# La carpeta shared de consul
+PROJECT_FOLDER=/var/consul/shared
+# Nombre del proyecto
+PROJECT_NAME=valencia-pre
+# Nombre del bucket donde se guarda el backup
+S3_BACKUP_BUCKET_NAME=valencia
+# Nombre del backup, por defecto el día en formato YYYYMMDD
+NAME=${1:-$(date "+%Y%m%d")}
+
+if [ -z "${BACKUP_TYPE}" ]; then
+  BACKUP_TYPE="day"
+fi
+
+# DEFAULT SETTINGS
+SERVICES_HOME=$HOME
+
+BACKUP_FOLDER=${SERVICES_HOME}/backups
+LOCAL_KEEP=1
+if [ "$BACKUP_TYPE" == "month" ]; then
+  KEEP=12
+elif [ "$BACKUP_TYPE" == "week" ]; then
+  KEEP=4
+  if [[ $(date '+%d') == '01' ]]; then
+    # los primeros días de mes se hace backup mensual, no semanal
+    exit 0
+  fi
+else
+  KEEP=6
+  if [[ $(date '+%d') == '01' ]]; then
+    # los primeros días de mes se hace backup mensual, no diario
+    exit 0
+  fi
+fi
+
+echo Backup ${NAME} for project ${PROJECT_NAME}
+
+s3_backup_base_path=backup/${S3_BACKUP_BUCKET_NAME}/${PROJECT_NAME}/${BACKUP_TYPE}
+s3_backup_dir=${s3_backup_base_path}/${NAME}
+backup_base_path=${BACKUP_FOLDER}/${PROJECT_NAME}/${NAME}
+
+if [ ! -d $backup_base_path/config ]; then
+  mkdir -p $backup_base_path/config
+fi
+
+cp $PROJECT_FOLDER/config/database.yml $backup_base_path/config/database.yml
+encrypt $backup_base_path/config/database.yml
+cp $PROJECT_FOLDER/config/secrets.yml $backup_base_path/config/secrets.yml
+encrypt $backup_base_path/config/secrets.yml
+
+echo ${DATABASE_NAME} database backup
+host=$(get_database_field $PROJECT_FOLDER/config/database.yml host)
+db_name=$(get_database_field $PROJECT_FOLDER/config/database.yml database)
+username=$(get_database_field $PROJECT_FOLDER/config/database.yml username)
+password=$(get_database_field $PROJECT_FOLDER/config/database.yml password)
+database_url="postgresql://${username}:${password}@${host}:5432/${db_name}"
+db_dump_filename="${backup_base_path}/database.dump"
+pg_dump \
+  --clean \
+  --create \
+  --format=custom \
+  --compress=9 \
+  --file=${db_dump_filename} \
+  $database_url
+encrypt $db_dump_filename
+
+cd $PROJECT_FOLDER/storage
+tar czf ${backup_base_path}/storage.tar .
+cd -
+encrypt $backup_base_path/storage.tar
+
+mcli cp -r -q ${backup_base_path}/ ${s3_backup_dir}/
+
+clean_old_local_backups ${BACKUP_FOLDER}/${PROJECT_NAME} $LOCAL_KEEP
+clean_old_remote_backups $s3_backup_base_path $KEEP

--- a/create_backup.sh
+++ b/create_backup.sh
@@ -67,7 +67,7 @@ shift $(($OPTIND - 1))
 # La carpeta shared de consul
 PROJECT_FOLDER=/var/consul/shared
 # Nombre del proyecto
-PROJECT_NAME=valencia-pre
+PROJECT_NAME=valencia-production
 # Nombre del bucket donde se guarda el backup
 S3_BACKUP_BUCKET_NAME=valencia
 # Nombre del backup, por defecto el día en formato YYYYMMDD

--- a/lib/capistrano/tasks/backup.cap
+++ b/lib/capistrano/tasks/backup.cap
@@ -1,0 +1,73 @@
+namespace :backup do
+  desc "Install backup cron entries after checking prerequisites"
+  task :install do
+    invoke "backup:install_mcli"
+    invoke "backup:install_gpg_key"
+    invoke "backup:check_prerequisites"
+    invoke "whenever:update_crontab"
+  end
+
+  desc "Install the MinIO client binary as mcli in /usr/local/bin"
+  task :install_mcli do
+    on roles(:cron) do |host|
+      if test("command -v mcli >/dev/null 2>&1")
+        info "mcli already installed on #{host.hostname}"
+      else
+        arch = capture("uname -m").strip
+        platform = arch == "aarch64" ? "linux-arm64" : "linux-amd64"
+        mc_url = "https://dl.min.io/client/mc/release/#{platform}/mc"
+        execute "curl -fsSL #{mc_url} -o /tmp/mcli"
+        sudo "install -m 0755 /tmp/mcli /usr/local/bin/mcli"
+        execute "rm -f /tmp/mcli"
+        info "mcli installed on #{host.hostname}"
+      end
+    end
+  end
+
+  desc "Install GPG public key for seguridad@osoigo.com (set GPG_PUBLIC_KEY_PATH=...)"
+  task :install_gpg_key do
+    gpg_public_key_path = ENV.fetch("GPG_PUBLIC_KEY_PATH", "config/keys/seguridad.gpg.pub")
+
+    unless File.exist?(gpg_public_key_path)
+      raise "GPG public key file not found: #{gpg_public_key_path}. Set GPG_PUBLIC_KEY_PATH to a valid local path"
+    end
+
+    on roles(:cron) do |host|
+      if test("gpg --batch --list-keys --with-colons seguridad@osoigo.com | grep -q '^pub:'")
+        info "GPG key seguridad@osoigo.com already present on #{host.hostname}"
+      else
+        upload! gpg_public_key_path, "/tmp/seguridad.gpg.pub"
+        execute "mkdir -p $HOME/.gnupg && chmod 700 $HOME/.gnupg"
+        execute "gpg --batch --import /tmp/seguridad.gpg.pub"
+        execute "rm -f /tmp/seguridad.gpg.pub"
+
+        unless test("gpg --batch --list-keys --with-colons seguridad@osoigo.com | grep -q '^pub:'")
+          raise "GPG key seguridad@osoigo.com could not be imported on #{host.hostname}"
+        end
+
+        info "GPG key seguridad@osoigo.com installed on #{host.hostname}"
+      end
+    end
+  end
+
+  desc "Check backup prerequisites (mcli and GPG key seguridad@osoigo.com)"
+  task :check_prerequisites do
+    on roles(:cron) do |host|
+      unless test("command -v mcli >/dev/null 2>&1 || test -x $HOME/bin/mcli")
+        invoke "backup:install_mcli"
+      end
+
+      unless test("command -v gpg >/dev/null 2>&1")
+        raise "gpg is not installed for #{host.hostname}"
+      end
+
+      unless test("gpg --batch --list-keys --with-colons seguridad@osoigo.com | grep -q '^pub:'")
+        raise "GPG key seguridad@osoigo.com not found for #{host.hostname}"
+      end
+
+      info "Backup prerequisites OK on #{host.hostname}"
+    end
+  end
+end
+
+before "whenever:update_crontab", "backup:check_prerequisites"

--- a/lib/capistrano/tasks/backup.cap
+++ b/lib/capistrano/tasks/backup.cap
@@ -9,7 +9,7 @@ namespace :backup do
 
   desc "Install the MinIO client binary as mcli in /usr/local/bin"
   task :install_mcli do
-    on roles(:cron) do |host|
+    on roles(:backup) do |host|
       if test("command -v mcli >/dev/null 2>&1")
         info "mcli already installed on #{host.hostname}"
       else
@@ -32,7 +32,7 @@ namespace :backup do
       raise "GPG public key file not found: #{gpg_public_key_path}. Set GPG_PUBLIC_KEY_PATH to a valid local path"
     end
 
-    on roles(:cron) do |host|
+    on roles(:backup) do |host|
       if test("gpg --batch --list-keys --with-colons seguridad@osoigo.com | grep -q '^pub:'")
         info "GPG key seguridad@osoigo.com already present on #{host.hostname}"
       else
@@ -52,7 +52,7 @@ namespace :backup do
 
   desc "Check backup prerequisites (mcli and GPG key seguridad@osoigo.com)"
   task :check_prerequisites do
-    on roles(:cron) do |host|
+    on roles(:backup) do |host|
       unless test("command -v mcli >/dev/null 2>&1 || test -x $HOME/bin/mcli")
         invoke "backup:install_mcli"
       end


### PR DESCRIPTION
## Resumen

Esta PR incorpora la automatización de backups cifrados en preproducción usando Capistrano + Whenever.

Incluye:

- Script de backup con soporte de frecuencia diaria, semanal y mensual.
- Programación de cron jobs vía Whenever.
- Tareas Capistrano para instalación de dependencias, instalación de clave GPG y validación de prerrequisitos.
- Flujo unificado de instalación para dejar todo operativo en un solo comando.

## Cambios incluidos

### 1. Script de backup

Se añade el script de backup, que:

- Genera backup de base de datos y storage.
- Cifra artefactos con GPG para `seguridad@osoigo.com`.
- Sube backups al almacenamiento S3 compatible MinIO.
- Aplica política de retención por tipo de backup:
  - `day`
  - `week`
  - `month`

### 2. Cron jobs con Whenever

Se actualiza `config/schedule.rb` para programar:

- Diario: `create_backup.sh -t day`
- Semanal: `create_backup.sh -t week`
- Mensual: `create_backup.sh -t month`

### 3. Tareas Capistrano de backup

Se añade `lib/capistrano/tasks/backup.cap` con tareas para instalación y validación.

## Tareas Capistrano disponibles

### Tareas nuevas de backup

- `bundle exec cap preproduction backup:install`  
  Flujo completo: `install_mcli` -> `install_gpg_key` -> `check_prerequisites` -> `whenever:update_crontab`.

- `bundle exec cap preproduction backup:install_mcli`  
  Instala MinIO client como `mcli` en `/usr/local/bin` si no existe.

- `bundle exec cap preproduction backup:install_gpg_key`  
  Importa la clave pública GPG de `seguridad@osoigo.com` en el usuario `deploy`.  
  Acepta variable local:
  `GPG_PUBLIC_KEY_PATH=/ruta/local/seguridad.gpg.pub`

- `bundle exec cap preproduction backup:check_prerequisites`  
  Verifica que existen `mcli`, `gpg` y la clave `seguridad@osoigo.com`.

### Tareas de Whenever relacionadas

- `bundle exec cap preproduction whenever:update_crontab`  
  Instala/actualiza las entradas de cron gestionadas por Whenever.

- `bundle exec cap preproduction whenever:clear_crontab`  
  Elimina las entradas de cron gestionadas por Whenever.

## Ejecución recomendada

1. Ejecutar instalación completa:
   `GPG_PUBLIC_KEY_PATH=/ruta/local/seguridad.gpg.pub bundle exec cap preproduction backup:install`

2. Verificar tareas disponibles:
   `bundle exec cap -T | rg "backup:|whenever:"`

## Notas

- La instalación es idempotente:
  - `mcli` no se reinstala si ya existe.
  - la clave GPG no se vuelve a importar si ya está presente.
- Si no se proporciona clave y no existe en ruta por defecto, el proceso falla pronto con mensaje explícito para evitar despliegues incompletos.
