### PR TITLE
Add pre-commit hook and setup script for Pronto code quality checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Prerequisites: install git, Ruby 3.2.8, CMake, pkg-config, Node.js 18.20.3, Imag
 git clone https://github.com/consuldemocracy/consuldemocracy.git
 cd consuldemocracy
 bin/setup
+bash scripts/setup-hooks.sh
 bin/rake db:dev_seed
 ```
 
@@ -59,6 +60,43 @@ bin/rspec
 ```
 
 Note: running the whole test suite on your machine might take more than an hour, so it's strongly recommended that you setup a Continuous Integration system in order to run them using parallel jobs every time you open or modify a pull request (if you use GitHub Actions or GitLab CI, this is already configured in `.github/workflows/tests.yml` and `.gitlab-ci.yml`) and only run tests related to your current task while developing on your machine. When you configure the application for the first time, it's recommended that you run at least one test in `spec/models/` and one test in `spec/system/` to check your machine is properly configured to run the tests.
+
+### Code Quality
+
+You can run Pronto to check code quality on your changes. Pronto analyzes code using multiple linters: RuboCop (Ruby), ESLint (JavaScript), Stylelint (CSS/SCSS), and ERB Lint (templates).
+
+**Run Pronto on staged changes only** (recommended for pre-commit):
+
+```bash
+bundle exec pronto run
+```
+
+**Run Pronto comparing against a specific branch:**
+
+```bash
+bundle exec pronto run -c origin/main
+```
+
+**Run Pronto comparing against a previous commit (staged and unstaged changes):**
+
+```bash
+bundle exec pronto run -c HEAD~1
+```
+
+**Run a specific linter:**
+
+```bash
+bundle exec pronto run -r rubocop     # Only Ruby
+bundle exec pronto run -r eslint      # Only JavaScript
+bundle exec pronto run -r stylelint   # Only CSS/SCSS
+bundle exec pronto run -r erb_lint    # Only templates
+```
+
+Pronto automatically runs on every commit via a pre-commit hook that was installed during setup. To bypass it:
+
+```bash
+git commit --no-verify
+```
 
 You can use the default admin user from the seeds file:
 

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Pre-commit hook para ejecutar Pronto
+# Detecta problemas de código antes de hacer commit
+
+set -e
+
+echo "🔍 Ejecutando Pronto..."
+
+# Ejecutar Pronto contra cambios staged
+if ! bundle exec pronto run; then
+    echo ""
+    echo "❌ Pronto encontró problemas. Commit cancelado."
+    echo "Para ver detalles específicos, ejecuta:"
+    echo "  bundle exec pronto run -r rubocop    # Solo Ruby"
+    echo "  bundle exec pronto run -r eslint     # Solo JavaScript"
+    echo "  bundle exec pronto run -r stylelint  # Solo CSS/SCSS"
+    echo "  bundle exec pronto run -r erb_lint   # Solo templates ERB"
+    exit 1
+fi
+
+echo "✅ Pronto OK - Commit permitido"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Script para instalar git hooks
+# Copia los hooks de scripts/hooks/ a .git/hooks/
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GIT_HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+echo "📦 Instalando git hooks..."
+
+# Crear directorio de hooks si no existe
+mkdir -p "$GIT_HOOKS_DIR"
+
+# Copiar y dar permisos a los hooks
+for hook in "$SCRIPT_DIR/hooks"/*; do
+    if [ -f "$hook" ]; then
+        hook_name=$(basename "$hook")
+        cp "$hook" "$GIT_HOOKS_DIR/$hook_name"
+        chmod +x "$GIT_HOOKS_DIR/$hook_name"
+        echo "✅ Instalado: $hook_name"
+    fi
+done
+
+echo "✨ Git hooks instalados correctamente"


### PR DESCRIPTION
Provides scripts to configure Pronto to run automatically before each commit, catching code quality issues early.

**Changes:**
- Add `scripts/hooks/pre-commit` — git hook that runs Pronto on staged changes before allowing a commit
- Add `scripts/setup-hooks.sh` — setup script that installs the git hooks into `.git/hooks/`
- Update `README.md` — adds `bash scripts/setup-hooks.sh` to the setup instructions and a new _Code Quality_ section with usage examples

**How to set up:**
```bash
bash scripts/setup-hooks.sh
```

This only needs to be done once after cloning the repository. From that point, Pronto will run automatically on every `git commit`, blocking it if any issues are found. To bypass the hook:
```bash
git commit --no-verify
```