### PR TITLE
Resultados y estadisticas de presupuestos personalizados

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -20,6 +20,7 @@ linters:
       - app/components/layout/subnavigation_component.html.erb
       - app/components/layout/top_links_component.html.erb
       - app/views/admin/site_customization/content_blocks/index.html.erb
+      - app/views/custom/budgets/results/show.html.erb
       - app/views/custom/budgets/stats/show.html.erb
       - app/views/layouts/application.html.erb
       - app/views/layouts/dashboard.html.erb

--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -20,6 +20,7 @@ linters:
       - app/components/layout/subnavigation_component.html.erb
       - app/components/layout/top_links_component.html.erb
       - app/views/admin/site_customization/content_blocks/index.html.erb
+      - app/views/custom/budgets/stats/show.html.erb
       - app/views/layouts/application.html.erb
       - app/views/layouts/dashboard.html.erb
       - app/views/layouts/devise.html.erb

--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -101,5 +101,9 @@ CKEDITOR.editorConfig = function( config )
     { name: "insert", items: [ "Image", "Table" ] }
   ]);
 
+  config.toolbar_admin_extended = config.toolbar_admin.concat([
+    { name: "document", items: [ "Source" ] }
+  ]);
+
   config.toolbar = "mini";
 };

--- a/app/assets/javascripts/html_editor.js
+++ b/app/assets/javascripts/html_editor.js
@@ -3,7 +3,9 @@
   App.HTMLEditor = {
     initialize: function() {
       $("textarea.html-area").each(function() {
-        if ($(this).hasClass("admin")) {
+        if ($(this).hasClass("admin-extended")) {
+          CKEDITOR.replace(this.name, { language: $("html").attr("lang"), toolbar: "admin_extended", height: 500 });
+        } else if ($(this).hasClass("admin")) {
           CKEDITOR.replace(this.name, { language: $("html").attr("lang"), toolbar: "admin", height: 500 });
         } else {
           CKEDITOR.replace(this.name, { language: $("html").attr("lang") });

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -70,6 +70,10 @@ h6,
 /******************************************
 *** MENU
 ******************************************/
+[data-responsive-toggle="responsive_menu"] .menu-icon {
+  color: #000;
+}
+
 .top-links a,
 .account-menu.menu li a {
   color: initial;
@@ -143,6 +147,7 @@ h6,
 //assets/images/custom/header/header_sm_val.png
 .custom-header-card-full-link {
   color: #000;
+  display: block;
   position: relative;
   text-decoration: none;
 
@@ -420,5 +425,76 @@ h6,
     margin-bottom: $line-height * 2;
     min-width: 30%;
     text-decoration: none;
+  }
+}
+/******************************************
+*** OVERRIDE STATS
+******************************************/
+.participation-stats {
+  h2 {
+    border-bottom: 1px solid #dee0e3;
+    font-size: 1.5rem;
+  }
+
+  h3 {
+    font-size: 1.1875rem;
+    font-weight: 700;
+  }
+
+  p em {
+    color: #222;
+    font-size: 0.8125rem;
+    font-style: italic;
+    line-height: 1.25rem;
+    margin-top: 0;
+    text-wrap: nowrap;
+  }
+
+  table {
+    display: inherit;
+    max-width: 100dvw;
+    overflow-x: auto;
+    overflow-y: hidden;
+
+    tr td {
+      padding: 0.75rem;
+    }
+  }
+
+  table tr td p {
+    margin-bottom: 0;
+
+    strong {
+      font-size: 2.25rem;
+    }
+
+    em {
+      color: #515151;
+      font-size: 0.875rem;
+    }
+  }
+
+  td:has(table.progress) {
+    padding: 0 0.5rem 0.5rem;
+  }
+
+  table.progress {
+    border-radius: 1.25rem;
+    display: table;
+    width: 260px !important;
+
+    tr td {
+      border-radius: 1.25rem;
+      line-height: 0.75rem;
+      padding: 0;
+
+      &:nth-child(1) {
+        background-color: #52a4ee;
+      }
+
+      &:nth-child(2) {
+        background-color: #ebf0f4;
+      }
+    }
   }
 }

--- a/app/components/custom/admin/budgets/form_component.html.erb
+++ b/app/components/custom/admin/budgets/form_component.html.erb
@@ -62,6 +62,24 @@
                          step: 0.1,
                          label: t("admin.budgets.edit.negative_vote_value") %>
     </div>
+    <%= f.fields_for :extension, budget.extension || budget.build_extension do |extension_form| %>
+      <div class="row expanded">
+        <div class="small-12 column">
+          <p class="form-label"><%= t("admin.budgets.edit.stats_override") %></p>
+          <p class="help-text"><%= t("admin.budgets.edit.stats_override_help_text") %></p>
+          <%= extension_form.check_box :stats_override,
+                                       data: { checkbox_toggle: ".stats-override-fields" } %>
+        </div>
+      </div>
+      <% override_style = extension_form.object.stats_override? ? "" : "display:none" %>
+      <%= extension_form.translatable_fields do |translations_form| %>
+        <div class="stats-override-fields row expanded" style="<%= override_style %>">
+          <div class="small-12 column">
+            <%= translations_form.text_area :stats_override_content, class: "html-area admin-extended" %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
   </fieldset>
   <fieldset>
     <legend><%= t("admin.budgets.edit.info.staff_settings") %></legend>

--- a/app/components/custom/admin/budgets/form_component.html.erb
+++ b/app/components/custom/admin/budgets/form_component.html.erb
@@ -62,7 +62,7 @@
                          step: 0.1,
                          label: t("admin.budgets.edit.negative_vote_value") %>
     </div>
-    <%= f.fields_for :extension, budget.extension || budget.build_extension do |extension_form| %>
+    <%= f.fields_for :extension, budget.extension_for_editing do |extension_form| %>
       <div class="row expanded">
         <div class="small-12 column">
           <p class="form-label"><%= t("admin.budgets.edit.stats_override") %></p>

--- a/app/components/custom/admin/budgets/form_component.html.erb
+++ b/app/components/custom/admin/budgets/form_component.html.erb
@@ -71,11 +71,25 @@
                                        data: { checkbox_toggle: ".stats-override-fields" } %>
         </div>
       </div>
+      <div class="row expanded">
+        <div class="small-12 column">
+          <p class="form-label"><%= t("admin.budgets.edit.results_extension") %></p>
+          <p class="help-text"><%= t("admin.budgets.edit.results_extension_help_text") %></p>
+          <%= extension_form.check_box :results_extension,
+                                       data: { checkbox_toggle: ".results-extension-fields" } %>
+        </div>
+      </div>
       <% override_style = extension_form.object.stats_override? ? "" : "display:none" %>
+      <% extension_style = extension_form.object.results_extension? ? "" : "display:none" %>
       <%= extension_form.translatable_fields do |translations_form| %>
         <div class="stats-override-fields row expanded" style="<%= override_style %>">
           <div class="small-12 column">
             <%= translations_form.text_area :stats_override_content, class: "html-area admin-extended" %>
+          </div>
+        </div>
+        <div class="results-extension-fields row expanded" style="<%= extension_style %>">
+          <div class="small-12 column">
+            <%= translations_form.text_area :results_extension_content, class: "html-area admin-extended" %>
           </div>
         </div>
       <% end %>

--- a/app/components/custom/budgets/executions/investments_component.html.erb
+++ b/app/components/custom/budgets/executions/investments_component.html.erb
@@ -21,7 +21,7 @@
           <td><%= investment.formatted_price %></td>
           <td>
             <% status = investment.milestones.published.with_status.order_by_publication_date.last&.status %>
-            <%= status.name %>
+            <%= status&.name %>
           </td>
         </tr>
       <% end %>

--- a/app/controllers/custom/admin/budgets_controller.rb
+++ b/app/controllers/custom/admin/budgets_controller.rb
@@ -5,7 +5,13 @@ class Admin::BudgetsController
 
   def allowed_params
     consul_allowed_params + [
-      :negative_votes, :negative_vote_value
+      :negative_votes,
+      :negative_vote_value,
+      extension_attributes: [
+        :id,
+        :stats_override,
+        translation_params(Budget::Extension)
+      ]
     ]
   end
 

--- a/app/controllers/custom/admin/budgets_controller.rb
+++ b/app/controllers/custom/admin/budgets_controller.rb
@@ -10,6 +10,7 @@ class Admin::BudgetsController
       extension_attributes: [
         :id,
         :stats_override,
+        :results_extension,
         translation_params(Budget::Extension)
       ]
     ]

--- a/app/models/custom/budget.rb
+++ b/app/models/custom/budget.rb
@@ -10,9 +10,10 @@ class Budget
 
   def extension_for_editing
     ext = extension || build_extension
+    existing_locales = ext.translations.map(&:locale)
 
-    if ext.new_record?
-      locales_not_marked_for_destruction.each { |locale| ext.translations.build(locale: locale) }
+    locales_not_marked_for_destruction.each do |locale|
+      ext.translations.build(locale: locale) unless existing_locales.include?(locale)
     end
 
     ext

--- a/app/models/custom/budget.rb
+++ b/app/models/custom/budget.rb
@@ -8,6 +8,16 @@ class Budget
            :results_extension?, :results_extension_content,
            to: :extension, allow_nil: true
 
+  def extension_for_editing
+    ext = extension || build_extension
+
+    if ext.new_record?
+      locales_not_marked_for_destruction.each { |locale| ext.translations.build(locale: locale) }
+    end
+
+    ext
+  end
+
   def negative_votes?
     negative_votes > 0
   end

--- a/app/models/custom/budget.rb
+++ b/app/models/custom/budget.rb
@@ -4,7 +4,9 @@ class Budget
   has_one :extension, class_name: "Budget::Extension", dependent: :destroy
   accepts_nested_attributes_for :extension
 
-  delegate :stats_override?, :stats_override_content, to: :extension, allow_nil: true
+  delegate :stats_override?, :stats_override_content,
+           :results_extension?, :results_extension_content,
+           to: :extension, allow_nil: true
 
   def negative_votes?
     negative_votes > 0

--- a/app/models/custom/budget.rb
+++ b/app/models/custom/budget.rb
@@ -1,6 +1,11 @@
 load Rails.root.join("app", "models", "budget.rb")
 
 class Budget
+  has_one :extension, class_name: "Budget::Extension", dependent: :destroy
+  accepts_nested_attributes_for :extension
+
+  delegate :stats_override?, :stats_override_content, to: :extension, allow_nil: true
+
   def negative_votes?
     negative_votes > 0
   end

--- a/app/models/custom/budget/extension.rb
+++ b/app/models/custom/budget/extension.rb
@@ -3,6 +3,7 @@ class Budget
     belongs_to :budget
 
     translates :stats_override_content
+    translates :results_extension_content
     include Globalizable
   end
 end

--- a/app/models/custom/budget/extension.rb
+++ b/app/models/custom/budget/extension.rb
@@ -1,0 +1,8 @@
+class Budget
+  class Extension < ApplicationRecord
+    belongs_to :budget
+
+    translates :stats_override_content
+    include Globalizable
+  end
+end

--- a/app/views/custom/budgets/results/show.html.erb
+++ b/app/views/custom/budgets/results/show.html.erb
@@ -71,3 +71,10 @@
     </p>
   </div>
 </div>
+<% if @budget.results_extension? && @budget.results_extension_content.present? %>
+  <div class="row">
+    <div class="small-12 column">
+      <%= raw @budget.results_extension_content %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/custom/budgets/stats/show.html.erb
+++ b/app/views/custom/budgets/stats/show.html.erb
@@ -1,0 +1,53 @@
+<% provide :title, t("stats.budgets.page_title", budget: @budget.name) %>
+<% provide :social_media_meta_tags do %>
+  <%= render "shared/social_media_meta_tags",
+             social_url: budget_stats_url(@budget),
+             social_title: @budget.name,
+             social_description: @budget.description_for_phase("finished") %>
+<% end %>
+
+<div class="participation-stats budgets-stats">
+  <div class="expanded no-margin-top padding header">
+    <div class="row">
+      <div class="small-12 column">
+        <%= back_link_to budget_path(@budget) %>
+        <h2 class="margin-top">
+          <%= t("stats.title") %><br>
+          <span><%= @budget.name %></span>
+        </h2>
+      </div>
+    </div>
+  </div>
+
+  <%= render "budgets/subnav", budget: @budget %>
+
+  <div class="row margin">
+    <div class="small-12 medium-3 column sidebar">
+      <%= render "shared/stats/links", stats: @stats %>
+      <%= render "advanced_stats_links" if @stats.advanced? %>
+    </div>
+
+    <div class="small-12 medium-9 column stats-content">
+      <%= render "shared/stats/participation", stats: @stats %>
+      <%= render Budgets::Stats::AdvancedStatsComponent.new(@stats) %>
+
+      <div class="row margin">
+        <div class="small-12 column">
+          <div id="total_no_demographic_data">
+            <% if @stats.total_no_demographic_data > 0 %>
+              <p class="help-text">
+                <%= t("stats.no_demographic_data", count: @stats.total_no_demographic_data) %>
+              </p>
+            <% end %>
+            <p class="help-text">
+              <%= t("stats.budgets.participatory_disclaimer") %>
+            </p>
+            <p class="help-text">
+              <%= t("stats.budgets.heading_disclaimer") %>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/custom/budgets/stats/show.html.erb
+++ b/app/views/custom/budgets/stats/show.html.erb
@@ -5,7 +5,6 @@
              social_title: @budget.name,
              social_description: @budget.description_for_phase("finished") %>
 <% end %>
-
 <div class="participation-stats budgets-stats">
   <div class="expanded no-margin-top padding header">
     <div class="row">
@@ -18,36 +17,40 @@
       </div>
     </div>
   </div>
-
   <%= render "budgets/subnav", budget: @budget %>
-
-  <div class="row margin">
-    <div class="small-12 medium-3 column sidebar">
-      <%= render "shared/stats/links", stats: @stats %>
-      <%= render "advanced_stats_links" if @stats.advanced? %>
+  <% if @budget.stats_override? %>
+    <div class="row margin">
+      <div class="small-12 column">
+        <%= raw @budget.stats_override_content %>
+      </div>
     </div>
-
-    <div class="small-12 medium-9 column stats-content">
-      <%= render "shared/stats/participation", stats: @stats %>
-      <%= render Budgets::Stats::AdvancedStatsComponent.new(@stats) %>
-
-      <div class="row margin">
-        <div class="small-12 column">
-          <div id="total_no_demographic_data">
-            <% if @stats.total_no_demographic_data > 0 %>
+  <% else %>
+    <div class="row margin">
+      <div class="small-12 medium-3 column sidebar">
+        <%= render "shared/stats/links", stats: @stats %>
+        <%= render "advanced_stats_links" if @stats.advanced? %>
+      </div>
+      <div class="small-12 medium-9 column stats-content">
+        <%= render "shared/stats/participation", stats: @stats %>
+        <%= render Budgets::Stats::AdvancedStatsComponent.new(@stats) %>
+        <div class="row margin">
+          <div class="small-12 column">
+            <div id="total_no_demographic_data">
+              <% if @stats.total_no_demographic_data > 0 %>
+                <p class="help-text">
+                  <%= t("stats.no_demographic_data", count: @stats.total_no_demographic_data) %>
+                </p>
+              <% end %>
               <p class="help-text">
-                <%= t("stats.no_demographic_data", count: @stats.total_no_demographic_data) %>
+                <%= t("stats.budgets.participatory_disclaimer") %>
               </p>
-            <% end %>
-            <p class="help-text">
-              <%= t("stats.budgets.participatory_disclaimer") %>
-            </p>
-            <p class="help-text">
-              <%= t("stats.budgets.heading_disclaimer") %>
-            </p>
+              <p class="help-text">
+                <%= t("stats.budgets.heading_disclaimer") %>
+              </p>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/config/locales/custom/en/activerecord.yml
+++ b/config/locales/custom/en/activerecord.yml
@@ -1,0 +1,7 @@
+en:
+  activerecord:
+    attributes:
+      budget/extension:
+        stats_override: "Override stats"
+      budget/extension/translation:
+        stats_override_content: "Stats HTML content"

--- a/config/locales/custom/en/activerecord.yml
+++ b/config/locales/custom/en/activerecord.yml
@@ -2,6 +2,8 @@ en:
   activerecord:
     attributes:
       budget/extension:
+        results_extension: "Results extension"
         stats_override: "Override stats"
       budget/extension/translation:
+        results_extension_content: "Results extension HTML content"
         stats_override_content: "Stats HTML content"

--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -6,6 +6,8 @@ en:
         negative_vote_value: Negative vote value
         stats_override: Override stats
         stats_override_help_text: Enable this option for budgets whose stats page cannot be automatically generated and requires custom HTML content.
+        results_extension: Show results extension
+        results_extension_help_text: Shows additional HTML content below the results table.
       winners:
         csvfile: CSV file
         done: Winner proposals established

--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -4,6 +4,8 @@ en:
       edit:
         negative_votes: Negative votes
         negative_vote_value: Negative vote value
+        stats_override: Override stats
+        stats_override_help_text: Enable this option for budgets whose stats page cannot be automatically generated and requires custom HTML content.
       winners:
         csvfile: CSV file
         done: Winner proposals established

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -1,5 +1,9 @@
 es:
   activerecord:
     attributes:
+      budget/extension:
+        stats_override: "Sobre-escribir estadísticas"
+      budget/extension/translation:
+        stats_override_content: "Contenido HTML de estadísticas"
       budget/heading:
         required_support: "Apoyos necesarios"

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -2,8 +2,10 @@ es:
   activerecord:
     attributes:
       budget/extension:
+        results_extension: "Extensión de resultados"
         stats_override: "Sobre-escribir estadísticas"
       budget/extension/translation:
+        results_extension_content: "Contenido HTML de extensión de resultados"
         stats_override_content: "Contenido HTML de estadísticas"
       budget/heading:
         required_support: "Apoyos necesarios"

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -5,8 +5,9 @@ es:
         negative_votes: "Votos negativos"
         negative_vote_value: "Valor de cada voto negativo"
         stats_override: "Sobre-escribir estadísticas"
-        stats_override_help_text: "Activa esta opción para presupuestos cuya página de estadísticas no puede generarse automáticamente y necesita contenido HTML personalizado."
-
+        stats_override_help_text: "Activa esta opción para presupuestos cuya página de estadístiques no puede generarse automáticamente y necesita contenido HTML personalizado."
+        results_extension: "Mostrar extensión de resultados"
+        results_extension_help_text: "Muestra contenido HTML adicional debajo de la tabla de resultados."
       winners:
         csvfile: Fichero CSV
         done: Propuestas ganadoras establecidas

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -4,6 +4,9 @@ es:
       edit:
         negative_votes: "Votos negativos"
         negative_vote_value: "Valor de cada voto negativo"
+        stats_override: "Sobre-escribir estadísticas"
+        stats_override_help_text: "Activa esta opción para presupuestos cuya página de estadísticas no puede generarse automáticamente y necesita contenido HTML personalizado."
+
       winners:
         csvfile: Fichero CSV
         done: Propuestas ganadoras establecidas

--- a/config/locales/custom/val/activerecord.yml
+++ b/config/locales/custom/val/activerecord.yml
@@ -1,0 +1,7 @@
+val:
+  activerecord:
+    attributes:
+      budget/extension:
+        stats_override: "Sobreescriure estadístiques"
+      budget/extension/translation:
+        stats_override_content: "Contingut HTML d'estadístiques"

--- a/config/locales/custom/val/activerecord.yml
+++ b/config/locales/custom/val/activerecord.yml
@@ -2,6 +2,8 @@ val:
   activerecord:
     attributes:
       budget/extension:
+        results_extension: "Extensió de resultats"
         stats_override: "Sobreescriure estadístiques"
       budget/extension/translation:
+        results_extension_content: "Contingut HTML d'extensió de resultats"
         stats_override_content: "Contingut HTML d'estadístiques"

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -6,6 +6,8 @@ val:
         negative_vote_value: "Valor de cada vot negatiu"
         stats_override: "Sobreescriure estadístiques"
         stats_override_help_text: "Activa aquesta opció per als pressupostos la pàgina d'estadístiques dels quals no es pot generar automàticament i necessita contingut HTML personalitzat."
+        results_extension: "Mostrar extensió de resultats"
+        results_extension_help_text: "Mostra contingut HTML addicional per davall de la taula de resultats."
       winners:
         csvfile: Ficher CSV
         done: Propostes guanyadores establides

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -4,6 +4,8 @@ val:
       edit:
         negative_votes: "Vots negatius"
         negative_vote_value: "Valor de cada vot negatiu"
+        stats_override: "Sobreescriure estadístiques"
+        stats_override_help_text: "Activa aquesta opció per als pressupostos la pàgina d'estadístiques dels quals no es pot generar automàticament i necessita contingut HTML personalitzat."
       winners:
         csvfile: Ficher CSV
         done: Propostes guanyadores establides

--- a/db/migrate/20260713100000_create_budget_extensions.rb
+++ b/db/migrate/20260713100000_create_budget_extensions.rb
@@ -1,0 +1,12 @@
+class CreateBudgetExtensions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :budget_extensions do |t|
+      t.integer :budget_id, null: false
+      t.boolean :stats_override, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index :budget_extensions, :budget_id, unique: true
+  end
+end

--- a/db/migrate/20260713100001_create_budget_extension_translations.rb
+++ b/db/migrate/20260713100001_create_budget_extension_translations.rb
@@ -1,0 +1,14 @@
+class CreateBudgetExtensionTranslations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :budget_extension_translations do |t|
+      t.integer :budget_extension_id, null: false
+      t.string :locale, null: false
+      t.text :stats_override_content
+
+      t.timestamps
+
+      t.index :budget_extension_id
+      t.index :locale
+    end
+  end
+end

--- a/db/migrate/20260713100002_add_results_extension_to_budget_extensions.rb
+++ b/db/migrate/20260713100002_add_results_extension_to_budget_extensions.rb
@@ -1,0 +1,6 @@
+class AddResultsExtensionToBudgetExtensions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :budget_extensions, :results_extension, :boolean, default: false, null: false
+    add_column :budget_extension_translations, :results_extension_content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_13_100032) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_13_100001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -208,6 +208,24 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_13_100032) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["heading_id"], name: "index_budget_content_blocks_on_heading_id"
+  end
+
+  create_table "budget_extension_translations", force: :cascade do |t|
+    t.integer "budget_extension_id", null: false
+    t.string "locale", null: false
+    t.text "stats_override_content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["budget_extension_id"], name: "index_budget_extension_translations_on_budget_extension_id"
+    t.index ["locale"], name: "index_budget_extension_translations_on_locale"
+  end
+
+  create_table "budget_extensions", force: :cascade do |t|
+    t.integer "budget_id", null: false
+    t.boolean "stats_override", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["budget_id"], name: "index_budget_extensions_on_budget_id", unique: true
   end
 
   create_table "budget_group_translations", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_13_100001) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_13_100002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -216,6 +216,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_13_100001) do
     t.text "stats_override_content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "results_extension_content"
     t.index ["budget_extension_id"], name: "index_budget_extension_translations_on_budget_extension_id"
     t.index ["locale"], name: "index_budget_extension_translations_on_locale"
   end
@@ -225,6 +226,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_13_100001) do
     t.boolean "stats_override", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "results_extension", default: false, null: false
     t.index ["budget_id"], name: "index_budget_extensions_on_budget_id", unique: true
   end
 

--- a/spec/components/custom/admin/budgets/form_component_spec.rb
+++ b/spec/components/custom/admin/budgets/form_component_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe Admin::Budgets::FormComponent, :admin do
+  describe "stats override section" do
+    it "renders the stats_override checkbox" do
+      render_inline Admin::Budgets::FormComponent.new(create(:budget))
+
+      expect(page).to have_field "budget[extension_attributes][stats_override]", type: :checkbox
+    end
+
+    it "hides the override fields container when stats_override is false" do
+      budget = create(:budget)
+      budget.create_extension!(stats_override: false)
+
+      render_inline Admin::Budgets::FormComponent.new(budget)
+
+      expect(page).to have_css ".stats-override-fields", visible: :hidden
+    end
+
+    it "shows the override fields container when stats_override is true" do
+      budget = create(:budget)
+      budget.create_extension!(stats_override: true)
+
+      render_inline Admin::Budgets::FormComponent.new(budget)
+
+      expect(page).to have_css ".stats-override-fields", visible: :visible
+    end
+
+    it "renders an html-area textarea for the stats content" do
+      budget = create(:budget)
+      budget.create_extension!(stats_override: true)
+
+      render_inline Admin::Budgets::FormComponent.new(budget)
+
+      expect(page).to have_css "textarea.html-area"
+    end
+  end
+end

--- a/spec/models/custom/budget/extension_spec.rb
+++ b/spec/models/custom/budget/extension_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe Budget::Extension do
+  describe "#stats_override_content" do
+    it "stores translatable HTML stats content" do
+      extension = create(:budget).create_extension!(stats_override_content: "<p>Stats</p>")
+
+      expect(extension.stats_override_content).to eq("<p>Stats</p>")
+    end
+  end
+
+  describe "#stats_override?" do
+    it "is false by default" do
+      extension = create(:budget).create_extension!
+
+      expect(extension.stats_override?).to be false
+    end
+
+    it "is true when the column is set" do
+      extension = create(:budget).create_extension!(stats_override: true)
+
+      expect(extension.stats_override?).to be true
+    end
+  end
+end

--- a/spec/models/custom/budget_spec.rb
+++ b/spec/models/custom/budget_spec.rb
@@ -23,6 +23,39 @@ describe Budget do
     end
   end
 
+  describe "#extension_for_editing" do
+    it "builds a new extension when the budget doesn't have one" do
+      budget = create(:budget)
+
+      expect(budget.extension_for_editing).to be_a(Budget::Extension).and be_new_record
+    end
+
+    it "returns the existing extension" do
+      budget = create(:budget)
+      extension = budget.create_extension!(stats_override: true)
+
+      expect(budget.extension_for_editing).to eq(extension)
+    end
+
+    it "pre-builds a translation, not marked for destruction, for every locale the budget already uses" do
+      budget = create(:budget)
+      budget.update!(name_fr: "Nom en français")
+
+      translations = budget.extension_for_editing.translations
+
+      expect(translations.map(&:locale)).to contain_exactly(*budget.locales_not_marked_for_destruction)
+      expect(translations.map(&:marked_for_destruction?)).to all(be false)
+    end
+
+    it "doesn't pre-build translations again for an already persisted extension" do
+      budget = create(:budget)
+      budget.update!(name_fr: "Nom en français")
+      budget.create_extension!(stats_override: true)
+
+      expect(budget.extension_for_editing.translations).to be_empty
+    end
+  end
+
   describe "#negative_votes?" do
     it "is false when negative_votes is zero" do
       expect(create(:budget, negative_votes: 0).negative_votes?).to be false

--- a/spec/models/custom/budget_spec.rb
+++ b/spec/models/custom/budget_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe Budget do
+  describe "#stats_override?" do
+    it "is falsey when there is no extension" do
+      expect(create(:budget).stats_override?).to be_falsey
+    end
+
+    it "delegates to the extension" do
+      budget = create(:budget)
+      budget.create_extension!(stats_override: true)
+
+      expect(budget.stats_override?).to be true
+    end
+  end
+
+  describe "#stats_override_content" do
+    it "delegates to the extension" do
+      budget = create(:budget)
+      budget.create_extension!(stats_override_content: "<p>Stats</p>")
+
+      expect(budget.stats_override_content).to eq("<p>Stats</p>")
+    end
+  end
+
+  describe "#negative_votes?" do
+    it "is false when negative_votes is zero" do
+      expect(create(:budget, negative_votes: 0).negative_votes?).to be false
+    end
+
+    it "is true when negative_votes is positive" do
+      expect(create(:budget, negative_votes: 1).negative_votes?).to be true
+    end
+  end
+end

--- a/spec/models/custom/budget_spec.rb
+++ b/spec/models/custom/budget_spec.rb
@@ -47,12 +47,25 @@ describe Budget do
       expect(translations.map(&:marked_for_destruction?)).to all(be false)
     end
 
-    it "doesn't pre-build translations again for an already persisted extension" do
+    it "doesn't duplicate a translation the persisted extension already has" do
+      budget = create(:budget)
+      extension = budget.create_extension!(stats_override: true, stats_override_content: "<p>Stats</p>")
+
+      translations = budget.extension_for_editing.translations
+
+      expect(translations).to contain_exactly(extension.translations.sole)
+    end
+
+    it "pre-builds a translation for a locale the budget uses but the persisted extension is missing" do
       budget = create(:budget)
       budget.update!(name_fr: "Nom en français")
-      budget.create_extension!(stats_override: true)
+      budget.create_extension!(stats_override: true, stats_override_content: "<p>Stats</p>")
 
-      expect(budget.extension_for_editing.translations).to be_empty
+      translations = budget.extension_for_editing.translations
+
+      expect(translations.map(&:locale)).to contain_exactly(*budget.locales_not_marked_for_destruction)
+      fr_translation = translations.find { |t| t.locale == :fr }
+      expect(fr_translation).not_to be_marked_for_destruction
     end
   end
 

--- a/spec/system/custom/admin/budgets_spec.rb
+++ b/spec/system/custom/admin/budgets_spec.rb
@@ -69,4 +69,38 @@ describe "Admin budget stats override", :admin do
       expect(translations[:fr].stats_override_content).to include("Contenu FR")
     end
   end
+
+  context "with an extension already persisted for only one of the budget's locales" do
+    let(:budget) do
+      b = create(:budget)
+      b.update!(name_fr: "Nom en français")
+      b.create_extension!(stats_override: true, stats_override_content: "Contenido EN existente")
+      b
+    end
+
+    before { Setting["locales.enabled"] = "en fr" }
+
+    scenario "saves stats_override_content for a locale the extension didn't have yet" do
+      visit edit_admin_budget_path(budget)
+
+      expect(page).to have_ckeditor("Stats HTML content", with: "Contenido EN existente")
+
+      page.execute_script(<<~JS)
+        var el = document.querySelector('.js-select-language');
+        el.value = 'fr';
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      JS
+
+      fill_in_ckeditor "Stats HTML content", with: "Contenido FR nuevo"
+      click_button "Update Budget"
+
+      expect(page).to have_content(I18n.t("admin.budgets.update.notice"))
+
+      budget.reload
+      translations = budget.extension.translations.index_by(&:locale)
+
+      expect(translations[:en].stats_override_content).to include("Contenido EN existente")
+      expect(translations[:fr].stats_override_content).to include("Contenido FR nuevo")
+    end
+  end
 end

--- a/spec/system/custom/admin/budgets_spec.rb
+++ b/spec/system/custom/admin/budgets_spec.rb
@@ -32,4 +32,41 @@ describe "Admin budget stats override", :admin do
     expect(page).to have_content(I18n.t("admin.budgets.update.notice"))
     expect(budget.reload.stats_override?).to be true
   end
+
+  context "with a budget that already uses more than one locale" do
+    let(:budget) do
+      b = create(:budget)
+      b.update!(name_fr: "Nom en français")
+      b
+    end
+
+    before { Setting["locales.enabled"] = "en fr" }
+
+    scenario "saves stats_override_content for a locale switched to via Current language" do
+      visit edit_admin_budget_path(budget)
+
+      check "budget[extension_attributes][stats_override]"
+      fill_in_ckeditor "Stats HTML content", with: "Contenido EN"
+
+      # Selects "fr" directly (instead of the "Current language" <select>) because that
+      # locale is already listed there (the budget's name is already translated into it),
+      # so an admin naturally uses it instead of "Add language" to reach it.
+      page.execute_script(<<~JS)
+        var el = document.querySelector('.js-select-language');
+        el.value = 'fr';
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      JS
+
+      fill_in_ckeditor "Stats HTML content", with: "Contenu FR"
+      click_button "Update Budget"
+
+      expect(page).to have_content(I18n.t("admin.budgets.update.notice"))
+
+      budget.reload
+      translations = budget.extension.translations.index_by(&:locale)
+
+      expect(translations[:en].stats_override_content).to include("Contenido EN")
+      expect(translations[:fr].stats_override_content).to include("Contenu FR")
+    end
+  end
 end

--- a/spec/system/custom/admin/budgets_spec.rb
+++ b/spec/system/custom/admin/budgets_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "Admin budget stats override", :admin do
+  let(:budget) { create(:budget) }
+
+  scenario "shows stats_override checkbox on edit form" do
+    visit edit_admin_budget_path(budget)
+
+    expect(page).to have_field "budget[extension_attributes][stats_override]", type: :checkbox
+  end
+
+  scenario "override fields are hidden when stats_override is false" do
+    visit edit_admin_budget_path(budget)
+
+    expect(page).to have_css ".stats-override-fields", visible: :hidden
+  end
+
+  scenario "override fields become visible when checkbox is checked" do
+    visit edit_admin_budget_path(budget)
+
+    check "budget[extension_attributes][stats_override]"
+
+    expect(page).to have_css ".stats-override-fields", visible: :visible
+  end
+
+  scenario "saves stats_override flag" do
+    visit edit_admin_budget_path(budget)
+
+    check "budget[extension_attributes][stats_override]"
+    click_button "Update Budget"
+
+    expect(page).to have_content(I18n.t("admin.budgets.update.notice"))
+    expect(budget.reload.stats_override?).to be true
+  end
+end

--- a/spec/system/custom/budgets/results_extension_spec.rb
+++ b/spec/system/custom/budgets/results_extension_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe "Budget results extension" do
+  let(:budget) { create(:budget, :finished) }
+  let(:group) { create(:budget_group, budget: budget) }
+  let(:heading) { create(:budget_heading, group: group, price: 1000) }
+
+  before do
+    create(:budget_investment, :selected, heading: heading, price: 200,
+                                          ballot_lines_count: 100)
+    Budget::Result.new(budget, heading).calculate_winners
+  end
+
+  context "when results_extension is active" do
+    before do
+      budget.create_extension!(results_extension: true,
+                               results_extension_content: "<p>Extension content</p>")
+    end
+
+    scenario "shows extension HTML below the results table" do
+      visit budget_results_path(budget)
+
+      expect(page).to have_content("Extension content")
+    end
+  end
+
+  context "when results_extension is inactive" do
+    scenario "does not show extension content" do
+      visit budget_results_path(budget)
+
+      expect(page).not_to have_css ".results-extension"
+    end
+  end
+end

--- a/spec/system/custom/budgets/stats_spec.rb
+++ b/spec/system/custom/budgets/stats_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Budget stats override" do
+  let(:budget) { create(:budget, :finished) }
+
+  context "when stats_override is active" do
+    before do
+      budget.create_extension!(stats_override: true, stats_override_content: "<p>Stats content</p>")
+    end
+
+    scenario "shows override HTML instead of the generated stats" do
+      visit budget_stats_path(budget)
+
+      expect(page).to have_content("Stats content")
+    end
+
+    scenario "does not render the stats sidebar" do
+      visit budget_stats_path(budget)
+
+      expect(page).not_to have_css ".sidebar"
+    end
+  end
+
+  context "when stats_override is inactive" do
+    scenario "shows the normal stats content" do
+      visit budget_stats_path(budget)
+
+      expect(page).to have_css ".stats-content"
+    end
+  end
+end


### PR DESCRIPTION
### Resumen

Permite configurar, por presupuesto, dos secciones de contenido HTML personalizado y traducible:

- **Override stats**: sustituye la página de estadísticas generada automáticamente por HTML editado a mano (útil cuando no es posible calcularlas automáticamente).
- **Results extension**: añade contenido HTML adicional debajo de la tabla de resultados del presupuesto.

Ambas secciones se activan mediante un checkbox en el panel de administración del presupuesto y su contenido es traducible (CKEditor, con la toolbar `admin-extended`, que incluye el botón *Source*).

### Arquitectura

En vez de añadir columnas y campos traducibles directamente sobre `Budget`/`Budget::Translation`, se ha creado un modelo nuevo:

- `Budget::Extension` (`has_one`/`belongs_to` con `Budget`), con tabla propia `budget_extensions` (`stats_override`, `results_extension`) y su propia tabla de traducciones Globalize `budget_extension_translations` (`stats_override_content`, `results_extension_content`).
- `Budget` expone `has_one :extension`, `accepts_nested_attributes_for :extension` y delega la lectura (`stats_override?`, `stats_override_content`, `results_extension?`, `results_extension_content`) a la extensión, para que las vistas públicas de stats/results no cambien.

**Por qué un modelo separado:** el formulario de administración de presupuestos ya tenía un único bloque `f.translatable_fields` para `name`/`main_link_text`/`main_link_url`. Añadir los dos campos nuevos ahí habría requerido llamar `translatable_fields` una segunda vez sobre el *mismo* modelo `Budget` dentro del mismo formulario, lo cual provoca un bug real en `accepts_nested_attributes_for`: para traducciones nuevas (sin `id`), cada llamada a `fields_for` genera un índice distinto, así que Rails termina creando varios registros `Budget::Translation` para el mismo idioma —cada uno con solo parte de los campos— y la validación de `name` presente falla en los que no lo tienen. Separar el contenido en `Budget::Extension` evita esto: cada modelo llama a `translatable_fields` una sola vez.

### Bug encontrado y corregido durante el desarrollo

Al tener **dos** modelos traducibles (`Budget` y `Budget::Extension`) en el mismo formulario, mientras que el selector de idioma (`shared/globalize_locales`) solo conoce al `Budget` padre, aparece un problema distinto: el desplegable "Idioma actual" lista los idiomas ya usados por el presupuesto (p. ej. Valenciano, si ya se usa en el nombre), pero cambiar de idioma con ese selector solo alterna visibilidad —nunca marca el idioma como "no destruido" para la extensión, que empieza cada campo nuevo marcado para destrucción salvo el idioma de sesión del administrador. Resultado: el admin rellena contenido en valenciano en un campo que parece normal y, al guardar, ese contenido se descarta silenciosamente.

Se ha confirmado que este mismo patrón (dos modelos Globalize anidados en un formulario, compartiendo un único selector) ya existe sin parchear en el propio core de Consul (`Legislation::Question`/`Legislation::QuestionOption`), así que no es un mal uso de `Globalizable`, sino una carencia genérica de `TranslatableFormBuilder`/`GlobalizeHelper` para este escenario concreto.

**Fix:** `Budget#extension_for_editing` construye (o recupera) la extensión y, para cada idioma que el presupuesto ya usa, crea una traducción sin marcar para destrucción si todavía no existe —tanto si la extensión es nueva como si ya estaba persistida y le faltaba ese idioma. No se ha tocado `translatable_form_builder.rb` ni `globalize_helper.rb` (código compartido por el resto de la aplicación).

### Migraciones

- `db/migrate/20260713100000_create_budget_extensions.rb`
- `db/migrate/20260713100001_create_budget_extension_translations.rb`
- `db/migrate/20260713100002_add_results_extension_to_budget_extensions.rb`

### Tests

- Modelo: `spec/models/custom/budget_spec.rb`, `spec/models/custom/budget/extension_spec.rb`
- Componente: `spec/components/custom/admin/budgets/form_component_spec.rb`
- Sistema: `spec/system/custom/admin/budgets_spec.rb`, `spec/system/custom/budgets/stats_spec.rb`, `spec/system/custom/budgets/results_extension_spec.rb`

Incluyen casos específicos de multi-idioma (idioma ya usado por el presupuesto, extensión nueva y extensión ya persistida a la que le falta un idioma) para cubrir el bug descrito arriba.
