### PR TITLE
feat: Mostrar ejecuciones de propuestas como tabla en vez de como card

### DIFF
--- a/app/components/custom/budgets/executions/filters_component.html.erb
+++ b/app/components/custom/budgets/executions/filters_component.html.erb
@@ -1,0 +1,25 @@
+<%= form_tag(budget_executions_path(budget), method: :get, class: "budget-executions-filters", id: "budget-executions-filters") do %>
+  <div class="filter">
+    <%= label_tag :milestone_tag, t("budgets.executions.filters.milestone_tag.label") %>
+    <%= select_tag :milestone_tag,
+                   options_for_select(
+                     options_for_milestone_tags,
+                     params[:milestone_tag]
+                   ),
+                   prompt: t("budgets.executions.filters.milestone_tag.all",
+                             count: budget.investments.winners.with_milestones.count) %>
+  </div>
+  <div class="filter">
+    <%= label_tag :status, t("budgets.executions.filters.status.label") %>
+    <%= select_tag :status,
+                   options_from_collection_for_select(statuses,
+                                                      :id,
+                                                      lambda { |s| "#{s.name} (#{filters_select_counts(s.id)})" },
+                                                      params[:status]),
+                   prompt: t("budgets.executions.filters.status.all",
+                             count: budget.investments.winners.with_milestones.count) %>
+  </div>
+  <div class="submit">
+    <%= submit_tag t("shared.filter") %>
+  </div>
+<% end %>

--- a/app/components/custom/budgets/executions/filters_component.rb
+++ b/app/components/custom/budgets/executions/filters_component.rb
@@ -1,0 +1,6 @@
+class Budgets::Executions::FiltersComponent < ApplicationComponent; end
+
+load Rails.root.join("app", "components", "budgets", "executions", "filters_component.rb")
+
+class Budgets::Executions::FiltersComponent
+end

--- a/app/components/custom/budgets/executions/investments_component.html.erb
+++ b/app/components/custom/budgets/executions/investments_component.html.erb
@@ -1,0 +1,42 @@
+<table id="budget-executions-table">
+  <thead>
+    <tr>
+      <th><%= t("budgets.executions.investment") %></th>
+      <th><%= t("budgets.executions.heading") %></th>
+      <th><%= t("budgets.executions.title") %></th>
+      <th><%= t("budgets.executions.ammount") %></th>
+      <th><%= t("budgets.executions.status") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% investments_by_heading.each do |heading, investments| %>
+      <% investments.each do |investment| %>
+        <tr>
+          <td><%= investment.id %></td>
+          <td><%= heading.name %></td>
+          <td>
+            <%= link_to investment.title,
+                        polymorphic_path(investment, anchor: "tab-milestones") %>
+          </td>
+          <td><%= investment.formatted_price %></td>
+          <td>
+            <% status = investment.milestones.published.with_status.order_by_publication_date.last&.status %>
+            <%= status.name %>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
+<%= button_tag t("budgets.executions.download_csv"), type: "submit", name: "format", value: "csv", form: "budget-executions-filters", class: "button float-right" %>
+
+<link href="//cdn.datatables.net/2.3.8/css/dataTables.dataTables.min.css" rel="stylesheet">
+<script src="//cdn.datatables.net/2.3.8/js/dataTables.min.js"></script>
+<script>
+  new DataTable('#budget-executions-table', {
+    language: {
+      url: 'https://cdn.datatables.net/plug-ins/1.11.5/i18n/es-ES.json'
+    },
+    order: [1, "asc"],
+  });
+</script>

--- a/app/components/custom/budgets/executions/investments_component.html.erb
+++ b/app/components/custom/budgets/executions/investments_component.html.erb
@@ -11,7 +11,7 @@
   <tbody>
     <% investments_by_heading.each do |heading, investments| %>
       <% investments.each do |investment| %>
-        <tr>
+        <tr class="budget-executions-investment">
           <td><%= investment.id %></td>
           <td><%= heading.name %></td>
           <td>

--- a/app/components/custom/budgets/executions/investments_component.rb
+++ b/app/components/custom/budgets/executions/investments_component.rb
@@ -1,0 +1,6 @@
+class Budgets::Executions::InvestmentsComponent < ApplicationComponent; end
+
+load Rails.root.join("app", "components", "budgets", "executions", "investments_component.rb")
+
+class Budgets::Executions::InvestmentsComponent < ApplicationComponent
+end

--- a/app/controllers/custom/budgets/executions_controller.rb
+++ b/app/controllers/custom/budgets/executions_controller.rb
@@ -1,0 +1,38 @@
+load Rails.root.join("app", "controllers", "budgets", "executions_controller.rb")
+
+class Budgets::ExecutionsController
+  alias_method :consul_show, :show
+
+  def show
+    consul_show
+    respond_to do |format|
+      format.html
+      format.csv do
+        data = CSV.generate() do |csv|
+          csv << [
+            "investment",
+            "heading",
+            "title",
+            "url",
+            "price",
+            "status"
+          ]
+          @investments_by_heading.each do |heading, investments|
+            investments.each do |investment|
+              status = investment.milestones.published.with_status.order_by_publication_date.last&.status
+              csv << [
+                investment.id,
+                heading.name,
+                investment.title,
+                polymorphic_url(investment, anchor: "tab-milestones"),
+                investment.price,
+                status.name
+              ]
+            end
+          end
+        end
+        send_data data, filename: "executions.csv"
+      end
+    end
+  end
+end

--- a/app/views/custom/budgets/executions/show.html.erb
+++ b/app/views/custom/budgets/executions/show.html.erb
@@ -1,0 +1,42 @@
+<% provide :title, t("budgets.executions.page_title", budget: @budget.name) %>
+<% content_for :meta_description do %><%= @budget.description_for_phase("finished") %><% end %>
+<% provide :social_media_meta_tags do %>
+  <%= render "shared/social_media_meta_tags",
+             social_url: budget_executions_url(@budget),
+             social_title: @budget.name,
+             social_description: @budget.description_for_phase("finished") %>
+<% end %>
+
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: budget_executions_url(@budget) %>
+<% end %>
+
+<div class="budgets-stats">
+  <div class="expanded no-margin-top padding header">
+    <div class="row">
+      <div class="small-12 column">
+        <%= back_link_to budget_path(@budget) %>
+        <h2 class="margin-top">
+          <%= t("budgets.executions.heading") %><br>
+          <span><%= @budget.name %></span>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%= render "budgets/subnav", budget: @budget %>
+
+<div class="row">
+  <div class="small-12 medium-9 large-10 column">
+    <%= render Budgets::Executions::FiltersComponent.new(@budget, @statuses) %>
+
+    <% if @investments_by_heading.any? %>
+      <%= render Budgets::Executions::InvestmentsComponent.new(@investments_by_heading) %>
+    <% else %>
+      <div class="callout primary clear">
+        <%= t("budgets.executions.no_winner_investments") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -36,3 +36,4 @@ en:
       title: "Título"
       ammount: "Ammount"
       status: "Status"
+      download_csv: "Download executions"

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -30,3 +30,9 @@ en:
     results:
       ballot_negativelines_count: Negative votes
       territorial_rebalance: "Selected by territorial rebalance"
+    executions:
+      investment: "Investement"
+      heading: "Heading"
+      title: "Título"
+      ammount: "Ammount"
+      status: "Status"

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -30,3 +30,9 @@ es:
     results:
       ballot_negativelines_count: Votos en contra
       territorial_rebalance: "Seleccionada por mecanismo de garantía."
+    executions:
+      investment: "Propuesta"
+      heading: "Distrito"
+      title: "Título"
+      ammount: "Presupuesto"
+      status: "Fase"

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -36,3 +36,4 @@ es:
       title: "Título"
       ammount: "Presupuesto"
       status: "Fase"
+      download_csv: "Descargar seguimiento"

--- a/config/locales/custom/val/budgets.yml
+++ b/config/locales/custom/val/budgets.yml
@@ -30,3 +30,9 @@ val:
     results:
       ballot_negativelines_count: Vots en contra
       territorial_rebalance: "Seleccionada per mecanisme de garantia."
+    executions:
+      investment: "Proposta"
+      heading: "Districte"
+      title: "Títol"
+      ammount: "Pressupost"
+      status: "Fase"

--- a/config/locales/custom/val/budgets.yml
+++ b/config/locales/custom/val/budgets.yml
@@ -36,3 +36,4 @@ val:
       title: "Títol"
       ammount: "Pressupost"
       status: "Fase"
+      download_csv: "Descarregar seguiment"

--- a/spec/system/budgets/executions_spec.rb
+++ b/spec/system/budgets/executions_spec.rb
@@ -83,7 +83,7 @@ describe "Executions" do
   end
 
   context "Images" do
-    scenario "renders default image if no milestone nor investment images are available" do
+    scenario "renders default image if no milestone nor investment images are available", :consul do
       create(:milestone, milestoneable: investment4)
 
       visit budget_executions_path(budget)


### PR DESCRIPTION
## Objectives

Mostrar información más clara en las ejecuciones de los proyectos de gasto

## Visual Changes

En vez de una lista de cards se muestra una tabla. También añade un enlace para poder descargarse el contenido de la tabla en formato csv.