### PR TITLE
Truncar los títulos de imagenes de las semillas de desarrollo

### DIFF
--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -42,9 +42,10 @@ end
 
 def add_image_to(imageable, sample_image_files)
   # imageable should respond to #title & #author
+  title_max = Setting["uploads.images.title.max_length"].to_i
   imageable.image = Image.create!({
     imageable: imageable,
-    title: imageable.title,
+    title: imageable.title.truncate(title_max.positive? ? title_max : imageable.title.length),
     attachment: Rack::Test::UploadedFile.new(sample_image_files.sample),
     user: imageable.author
   })


### PR DESCRIPTION
Para que `rails db:dev_seed` vuelva a funcionar con nuestra configuración personalizada en `app/models/custom/setting.rb`, donde hemos establecido la longitud máxima del título de las imágenes en 38.