### PR TITLE
Corregir el orden de «has_filters» en el BudgetInvestmentsController personalizado

### DIFF
--- a/app/controllers/custom/admin/budget_investments_controller.rb
+++ b/app/controllers/custom/admin/budget_investments_controller.rb
@@ -1,7 +1,7 @@
 load Rails.root.join("app", "controllers", "admin", "budget_investments_controller.rb")
 
 class Admin::BudgetInvestmentsController
-  include HasFilters
+  skip_before_action :load_investments
 
   has_filters %w[all without_admin
                  without_valuator under_valuation valuation_finished
@@ -10,6 +10,7 @@ class Admin::BudgetInvestmentsController
               only: :index
 
   before_action :load_counters, only: [:index]
+  before_action :load_investments, only: :index
 
   def index
     load_tags
@@ -29,13 +30,6 @@ class Admin::BudgetInvestmentsController
 
     def load_investments
       # Override the method to allow xlsx export without pagination
-
-      # repeat HasFilters functionality, overriding has_filters above didn't work
-      @valid_filters = %w[all without_admin
-                          without_valuator under_valuation valuation_finished
-                          enough_support not_enough_support
-                          winners]
-      @current_filter = @valid_filters.include?(params[:filter]) ? params[:filter] : @valid_filters.first
       @investments = Budget::Investment.scoped_filter(params, @current_filter).order_filter(params)
       @investments = Kaminari.paginate_array(@investments) if @investments.is_a?(Array)
       @investments = @investments.page(params[:page]) unless request.format.csv? || request.format.xlsx?


### PR DESCRIPTION
### Descripción

La llamada personalizada a `has_filters` se registraba como un `before_action` después de `:load_investments` (heredado del archivo original), por lo que `@current_filter` seguía establecido en «all» (procedente del `has_filters` original) cuando se ejecutaba `load_investments`.

Se ha solucionado omitiendo la llamada de retorno original :load_investments y volviéndola a registrar después de la llamada personalizada a has_filters, lo que garantiza que @current_filter esté correctamente establecido antes de que se carguen las inversiones. Esto también elimina la solución provisional manual que duplicaba la lógica de HasFilters en load_investments.